### PR TITLE
Feature filter types weaknesses

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -23,7 +23,7 @@
       "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.5.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/highlight": {
@@ -32,9 +32,9 @@
       "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "esutils": "2.0.3",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       }
     },
     "@protobufjs/aspromise": {
@@ -62,8 +62,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "requires": {
-        "@protobufjs/aspromise": "1.1.2",
-        "@protobufjs/inquire": "1.1.0"
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
       }
     },
     "@protobufjs/float": {
@@ -96,7 +96,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-w0vsEVz8dG4E/loFnfTOfns5FXU=",
       "requires": {
-        "@types/node": "12.0.2"
+        "@types/node": "*"
       }
     },
     "@types/body-parser": {
@@ -104,8 +104,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@types/body-parser/-/body-parser-1.17.0.tgz",
       "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
       "requires": {
-        "@types/connect": "3.4.32",
-        "@types/node": "12.0.2"
+        "@types/connect": "*",
+        "@types/node": "*"
       }
     },
     "@types/connect": {
@@ -113,7 +113,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@types/connect/-/connect-3.4.32.tgz",
       "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
       "requires": {
-        "@types/node": "12.0.2"
+        "@types/node": "*"
       }
     },
     "@types/cors": {
@@ -121,7 +121,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@types/cors/-/cors-2.8.5.tgz",
       "integrity": "sha1-wMVMTmQ+HZQ9RHKS8rr53ILPyOw=",
       "requires": {
-        "@types/express": "4.16.1"
+        "@types/express": "*"
       }
     },
     "@types/events": {
@@ -134,9 +134,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@types/express/-/express-4.16.1.tgz",
       "integrity": "sha1-11a9GoXDTYfq9EyIi60nuopLfPA=",
       "requires": {
-        "@types/body-parser": "1.17.0",
-        "@types/express-serve-static-core": "4.16.4",
-        "@types/serve-static": "1.13.2"
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -144,8 +144,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@types/express-serve-static-core/-/express-serve-static-core-4.16.4.tgz",
       "integrity": "sha1-VruL5FWUAdaK9KNiSundMWYQPmA=",
       "requires": {
-        "@types/node": "12.0.2",
-        "@types/range-parser": "1.2.3"
+        "@types/node": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/long": {
@@ -173,8 +173,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@types/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
       "requires": {
-        "@types/express-serve-static-core": "4.16.4",
-        "@types/mime": "2.0.1"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "@types/ws": {
@@ -182,8 +182,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/@types/ws/-/ws-6.0.1.tgz",
       "integrity": "sha1-yno/N1aqEvYqCmIUXtFMbbJdWig=",
       "requires": {
-        "@types/events": "3.0.0",
-        "@types/node": "12.0.2"
+        "@types/events": "*",
+        "@types/node": "*"
       }
     },
     "accepts": {
@@ -191,7 +191,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
       "requires": {
-        "mime-types": "2.1.24",
+        "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
     },
@@ -213,10 +213,10 @@
       "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
@@ -225,7 +225,7 @@
       "integrity": "sha1-TczbhGw+7hD21k3qZic+q5DDcig=",
       "dev": true,
       "requires": {
-        "type-fest": "0.5.2"
+        "type-fest": "^0.5.2"
       }
     },
     "ansi-regex": {
@@ -240,7 +240,7 @@
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "apollo-cache-control": {
@@ -267,10 +267,10 @@
       "integrity": "sha1-EN7z078/Ed2yR2XBnZyB4wy51Vw=",
       "requires": {
         "apollo-engine-reporting-protobuf": "0.3.0",
-        "apollo-graphql": "0.2.1-register.1",
+        "apollo-graphql": "^0.2.1-alpha.1",
         "apollo-server-core": "2.5.0",
         "apollo-server-env": "2.3.0",
-        "async-retry": "1.2.3",
+        "async-retry": "^1.2.1",
         "graphql-extensions": "0.6.0"
       }
     },
@@ -279,7 +279,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.3.0.tgz",
       "integrity": "sha1-LHZMBU/5loOHzxYRVUbg1bBO6fE=",
       "requires": {
-        "protobufjs": "6.8.8"
+        "protobufjs": "^6.8.6"
       }
     },
     "apollo-env": {
@@ -287,9 +287,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/apollo-env/-/apollo-env-0.5.1.tgz",
       "integrity": "sha1-ubAZXBb+rfD+n9VWPtsLm32el9M=",
       "requires": {
-        "core-js": "3.1.1",
-        "node-fetch": "2.6.0",
-        "sha.js": "2.4.11"
+        "core-js": "^3.0.1",
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
       }
     },
     "apollo-graphql": {
@@ -298,7 +298,7 @@
       "integrity": "sha1-lB3RZalCjC6jQHq0EPhCxAUM6ig=",
       "requires": {
         "apollo-env": "0.4.1-register.1",
-        "lodash.sortby": "4.7.0"
+        "lodash.sortby": "^4.7.0"
       },
       "dependencies": {
         "apollo-env": {
@@ -307,8 +307,8 @@
           "integrity": "sha1-6MlOIaWz+cRQiN7EeGLf4gJhEcI=",
           "requires": {
             "core-js": "3.0.0-beta.13",
-            "node-fetch": "2.6.0",
-            "sha.js": "2.4.11"
+            "node-fetch": "^2.2.0",
+            "sha.js": "^2.4.11"
           }
         },
         "core-js": {
@@ -323,10 +323,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/apollo-link/-/apollo-link-1.2.11.tgz",
       "integrity": "sha1-STKTt0etMjcRTM0i6fVZ5eJKGU0=",
       "requires": {
-        "apollo-utilities": "1.2.1",
-        "ts-invariant": "0.3.3",
-        "tslib": "1.9.3",
-        "zen-observable-ts": "0.8.18"
+        "apollo-utilities": "^1.2.1",
+        "ts-invariant": "^0.3.2",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.18"
       }
     },
     "apollo-server": {
@@ -336,9 +336,9 @@
       "requires": {
         "apollo-server-core": "2.5.0",
         "apollo-server-express": "2.5.0",
-        "express": "4.17.0",
-        "graphql-subscriptions": "1.1.0",
-        "graphql-tools": "4.0.4"
+        "express": "^4.0.0",
+        "graphql-subscriptions": "^1.0.0",
+        "graphql-tools": "^4.0.0"
       }
     },
     "apollo-server-caching": {
@@ -346,7 +346,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/apollo-server-caching/-/apollo-server-caching-0.4.0.tgz",
       "integrity": "sha1-6CkXWQ1yPArcH6UpAOeek61l5Nk=",
       "requires": {
-        "lru-cache": "5.1.1"
+        "lru-cache": "^5.0.0"
       }
     },
     "apollo-server-core": {
@@ -354,9 +354,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/apollo-server-core/-/apollo-server-core-2.5.0.tgz",
       "integrity": "sha1-ifwouhAY6/kkC8PMDBA/5wUwkCM=",
       "requires": {
-        "@apollographql/apollo-tools": "0.3.7",
-        "@apollographql/graphql-playground-html": "1.6.18",
-        "@types/ws": "6.0.1",
+        "@apollographql/apollo-tools": "^0.3.6-alpha.1",
+        "@apollographql/graphql-playground-html": "^1.6.6",
+        "@types/ws": "^6.0.0",
         "apollo-cache-control": "0.6.0",
         "apollo-datasource": "0.4.0",
         "apollo-engine-reporting": "1.1.0",
@@ -365,15 +365,15 @@
         "apollo-server-errors": "2.3.0",
         "apollo-server-plugin-base": "0.4.0",
         "apollo-tracing": "0.6.0",
-        "fast-json-stable-stringify": "2.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
         "graphql-extensions": "0.6.0",
-        "graphql-subscriptions": "1.1.0",
-        "graphql-tag": "2.10.1",
-        "graphql-tools": "4.0.4",
-        "graphql-upload": "8.0.6",
-        "sha.js": "2.4.11",
-        "subscriptions-transport-ws": "0.9.16",
-        "ws": "6.2.1"
+        "graphql-subscriptions": "^1.0.0",
+        "graphql-tag": "^2.9.2",
+        "graphql-tools": "^4.0.0",
+        "graphql-upload": "^8.0.2",
+        "sha.js": "^2.4.11",
+        "subscriptions-transport-ws": "^0.9.11",
+        "ws": "^6.0.0"
       }
     },
     "apollo-server-env": {
@@ -381,8 +381,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/apollo-server-env/-/apollo-server-env-2.3.0.tgz",
       "integrity": "sha1-8L9EhKbMMxqME3Y97VbpG+sWuhc=",
       "requires": {
-        "node-fetch": "2.6.0",
-        "util.promisify": "1.0.0"
+        "node-fetch": "^2.1.2",
+        "util.promisify": "^1.0.0"
       }
     },
     "apollo-server-errors": {
@@ -395,18 +395,18 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/apollo-server-express/-/apollo-server-express-2.5.0.tgz",
       "integrity": "sha1-/2y9P8uJM/YxbFpe3U2xLZpW+mU=",
       "requires": {
-        "@apollographql/graphql-playground-html": "1.6.18",
-        "@types/accepts": "1.3.5",
+        "@apollographql/graphql-playground-html": "^1.6.6",
+        "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.17.0",
-        "@types/cors": "2.8.5",
+        "@types/cors": "^2.8.4",
         "@types/express": "4.16.1",
-        "accepts": "1.3.7",
+        "accepts": "^1.3.5",
         "apollo-server-core": "2.5.0",
-        "body-parser": "1.19.0",
-        "cors": "2.8.5",
-        "graphql-subscriptions": "1.1.0",
-        "graphql-tools": "4.0.4",
-        "type-is": "1.6.18"
+        "body-parser": "^1.18.3",
+        "cors": "^2.8.4",
+        "graphql-subscriptions": "^1.0.0",
+        "graphql-tools": "^4.0.0",
+        "type-is": "^1.6.16"
       }
     },
     "apollo-server-plugin-base": {
@@ -428,9 +428,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/apollo-utilities/-/apollo-utilities-1.2.1.tgz",
       "integrity": "sha1-HDoev1YH18jv52NtqvWOdGO0Gzw=",
       "requires": {
-        "fast-json-stable-stringify": "2.0.0",
-        "ts-invariant": "0.2.1",
-        "tslib": "1.9.3"
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.2.1",
+        "tslib": "^1.9.3"
       },
       "dependencies": {
         "ts-invariant": {
@@ -438,7 +438,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/ts-invariant/-/ts-invariant-0.2.1.tgz",
           "integrity": "sha1-PVh/nW473tl7+ewXlR3ZgU1anT8=",
           "requires": {
-            "tslib": "1.9.3"
+            "tslib": "^1.9.3"
           }
         }
       }
@@ -449,7 +449,7 @@
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-find-index": {
@@ -469,8 +469,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "astral-regex": {
@@ -509,15 +509,15 @@
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "requires": {
         "bytes": "3.1.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.7.0",
         "raw-body": "2.4.0",
-        "type-is": "1.6.18"
+        "type-is": "~1.6.17"
       }
     },
     "brace-expansion": {
@@ -526,7 +526,7 @@
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -561,8 +561,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "chalk": {
@@ -571,9 +571,9 @@
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -588,7 +588,7 @@
       "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "3.1.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
@@ -657,8 +657,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/cors/-/cors-2.8.5.tgz",
       "integrity": "sha1-6sEdpRWS3Ya58G9uesKTs9+HXSk=",
       "requires": {
-        "object-assign": "4.1.1",
-        "vary": "1.1.2"
+        "object-assign": "^4",
+        "vary": "^1"
       }
     },
     "cross-spawn": {
@@ -667,11 +667,11 @@
       "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.7.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "currently-unhandled": {
@@ -680,7 +680,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "dateformat": {
@@ -689,8 +689,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "debounce": {
@@ -724,7 +724,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "depd": {
@@ -756,7 +756,7 @@
       "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.3"
+        "esutils": "^2.0.2"
       }
     },
     "dynamic-dedupe": {
@@ -765,7 +765,7 @@
       "integrity": "sha1-BuRMIj9eTpTXjvnbI6ZRXOL5YqE=",
       "dev": true,
       "requires": {
-        "xtend": "4.0.2"
+        "xtend": "^4.0.0"
       }
     },
     "ee-first": {
@@ -790,7 +790,7 @@
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -798,12 +798,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
       "requires": {
-        "es-to-primitive": "1.2.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4",
-        "object-keys": "1.1.1"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
@@ -811,9 +811,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.2"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-html": {
@@ -833,43 +833,43 @@
       "integrity": "sha1-BkOKSieLHYT7EH0k6qo1RxmG5kY=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "ajv": "6.10.2",
-        "chalk": "2.4.2",
-        "cross-spawn": "6.0.5",
-        "debug": "4.1.1",
-        "doctrine": "3.0.0",
-        "eslint-scope": "5.0.0",
-        "eslint-utils": "1.4.0",
-        "eslint-visitor-keys": "1.1.0",
-        "espree": "6.0.0",
-        "esquery": "1.0.1",
-        "esutils": "2.0.3",
-        "file-entry-cache": "5.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "glob-parent": "5.0.0",
-        "globals": "11.12.0",
-        "ignore": "4.0.6",
-        "import-fresh": "3.1.0",
-        "imurmurhash": "0.1.4",
-        "inquirer": "6.5.1",
-        "is-glob": "4.0.1",
-        "js-yaml": "3.13.1",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "progress": "2.0.3",
-        "regexpp": "2.0.1",
-        "semver": "6.3.0",
-        "strip-ansi": "5.2.0",
-        "strip-json-comments": "3.0.1",
-        "table": "5.4.6",
-        "text-table": "0.2.0",
-        "v8-compile-cache": "2.1.0"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^6.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "debug": {
@@ -878,7 +878,7 @@
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -901,7 +901,7 @@
       "integrity": "sha1-9CmlO96fx2YOY1ORD9mW1ihNPCU=",
       "dev": true,
       "requires": {
-        "get-stdin": "6.0.0"
+        "get-stdin": "^6.0.0"
       },
       "dependencies": {
         "get-stdin": {
@@ -924,8 +924,8 @@
       "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.11.0"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       }
     },
     "eslint-module-utils": {
@@ -934,8 +934,8 @@
       "integrity": "sha1-e0Z1h1v5aw2/GyGXdFblux9eAYw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "2.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
       }
     },
     "eslint-plugin-es": {
@@ -944,8 +944,8 @@
       "integrity": "sha1-R19luyDJk/wQ6Mj+d9HWAGgHLaY=",
       "dev": true,
       "requires": {
-        "eslint-utils": "1.4.0",
-        "regexpp": "2.0.1"
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
       }
     },
     "eslint-plugin-import": {
@@ -954,17 +954,17 @@
       "integrity": "sha1-AvEYC5Cwd7M9RHoXojJs60AKzrY=",
       "dev": true,
       "requires": {
-        "array-includes": "3.0.3",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.4.1",
-        "has": "1.0.3",
-        "minimatch": "3.0.4",
-        "object.values": "1.1.0",
-        "read-pkg-up": "2.0.0",
-        "resolve": "1.11.0"
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "doctrine": {
@@ -973,8 +973,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.3",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "find-up": {
@@ -983,7 +983,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -992,10 +992,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "path-type": {
@@ -1004,7 +1004,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -1013,9 +1013,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.5.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -1024,8 +1024,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -1042,12 +1042,12 @@
       "integrity": "sha1-8v2IUJox7GnbbpYG122rxa3BuRo=",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "1.4.0",
-        "eslint-utils": "1.4.0",
-        "ignore": "5.1.4",
-        "minimatch": "3.0.4",
-        "resolve": "1.11.0",
-        "semver": "6.3.0"
+        "eslint-plugin-es": "^1.4.0",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
       },
       "dependencies": {
         "ignore": {
@@ -1070,7 +1070,7 @@
       "integrity": "sha1-hpUYj5XaqTsNxUskk0fKO3nEaG0=",
       "dev": true,
       "requires": {
-        "prettier-linter-helpers": "1.0.0"
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-promise": {
@@ -1091,8 +1091,8 @@
       "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.3.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -1101,7 +1101,7 @@
       "integrity": "sha1-4sPI26doQl+JfPD55R/i4kFIXUw=",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "1.1.0"
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "eslint-visitor-keys": {
@@ -1116,9 +1116,9 @@
       "integrity": "sha1-cW/B9aJF71uaf9sdew0/AjIudfY=",
       "dev": true,
       "requires": {
-        "acorn": "6.3.0",
-        "acorn-jsx": "5.0.1",
-        "eslint-visitor-keys": "1.1.0"
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
@@ -1133,7 +1133,7 @@
       "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "dev": true,
       "requires": {
-        "estraverse": "4.3.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -1142,7 +1142,7 @@
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
-        "estraverse": "4.3.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -1172,36 +1172,36 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/express/-/express-4.17.0.tgz",
       "integrity": "sha1-KIr2IiinP0yOopkLo7eRu4fNRDg=",
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
         "body-parser": "1.19.0",
         "content-disposition": "0.5.3",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "finalhandler": "1.1.2",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.5",
+        "proxy-addr": "~2.0.5",
         "qs": "6.7.0",
-        "range-parser": "1.2.1",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
         "send": "0.17.1",
         "serve-static": "1.14.1",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
-        "type-is": "1.6.18",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "external-editor": {
@@ -1210,9 +1210,9 @@
       "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -1244,7 +1244,7 @@
       "integrity": "sha1-dWJ1yWRkYWPMb5GXx6ApXb/QTek=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1253,7 +1253,7 @@
       "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
       "dev": true,
       "requires": {
-        "flat-cache": "2.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "filewatcher": {
@@ -1262,7 +1262,7 @@
       "integrity": "sha1-9KGVc1Xdr0Q8zXiolfPVXiPIoDQ=",
       "dev": true,
       "requires": {
-        "debounce": "1.2.0"
+        "debounce": "^1.0.0"
       }
     },
     "finalhandler": {
@@ -1271,12 +1271,12 @@
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
-        "statuses": "1.5.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
       }
     },
     "find-up": {
@@ -1285,8 +1285,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -1295,7 +1295,7 @@
       "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
       "dev": true,
       "requires": {
-        "flatted": "2.0.1",
+        "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
@@ -1350,12 +1350,12 @@
       "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -1364,7 +1364,7 @@
       "integrity": "sha1-HcmfDzmwBtPpLCwoQGg4Lwwg6VQ=",
       "dev": true,
       "requires": {
-        "is-glob": "4.0.1"
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -1384,7 +1384,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/graphql/-/graphql-14.3.0.tgz",
       "integrity": "sha1-NN02+qSJ/2QrzSXfbDtPmIoaLz4=",
       "requires": {
-        "iterall": "1.2.2"
+        "iterall": "^1.2.2"
       }
     },
     "graphql-extensions": {
@@ -1392,7 +1392,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/graphql-extensions/-/graphql-extensions-0.6.0.tgz",
       "integrity": "sha1-PuOqV/4hP5Cuxc0xJ19tBHZ8aiM=",
       "requires": {
-        "@apollographql/apollo-tools": "0.3.7"
+        "@apollographql/apollo-tools": "^0.3.6-alpha.1"
       }
     },
     "graphql-subscriptions": {
@@ -1400,7 +1400,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
       "integrity": "sha1-Xy+kIz7aRM91cFJq3888FpN67xE=",
       "requires": {
-        "iterall": "1.2.2"
+        "iterall": "^1.2.1"
       }
     },
     "graphql-tag": {
@@ -1413,11 +1413,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/graphql-tools/-/graphql-tools-4.0.4.tgz",
       "integrity": "sha1-ygimNFQiH93oJf5F+9MV6yptVms=",
       "requires": {
-        "apollo-link": "1.2.11",
-        "apollo-utilities": "1.2.1",
-        "deprecated-decorator": "0.1.6",
-        "iterall": "1.2.2",
-        "uuid": "3.3.2"
+        "apollo-link": "^1.2.3",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
       }
     },
     "graphql-upload": {
@@ -1425,10 +1425,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/graphql-upload/-/graphql-upload-8.0.6.tgz",
       "integrity": "sha1-kPtiRpYtlTtk2d2r1kctjosRbuA=",
       "requires": {
-        "busboy": "0.3.1",
-        "fs-capacitor": "2.0.4",
-        "http-errors": "1.7.2",
-        "object-path": "0.11.4"
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^2.0.1",
+        "http-errors": "^1.7.2",
+        "object-path": "^0.11.4"
       }
     },
     "growly": {
@@ -1442,7 +1442,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -1467,10 +1467,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
     },
@@ -1479,7 +1479,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -1494,8 +1494,8 @@
       "integrity": "sha1-bTP6Hc7235MPrgA0RvM0Fa+QURg=",
       "dev": true,
       "requires": {
-        "parent-module": "1.0.1",
-        "resolve-from": "4.0.0"
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       }
     },
     "imurmurhash": {
@@ -1510,7 +1510,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -1519,8 +1519,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1534,19 +1534,19 @@
       "integrity": "sha1-i/t6WsAtrG/2QaxMX/F9oRL820I=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "4.2.1",
-        "chalk": "2.4.2",
-        "cli-cursor": "3.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "3.1.0",
-        "figures": "3.0.0",
-        "lodash": "4.17.15",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "2.3.0",
-        "rxjs": "6.5.2",
-        "string-width": "4.1.0",
-        "strip-ansi": "5.2.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
       }
     },
     "ipaddr.js": {
@@ -1582,7 +1582,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -1597,7 +1597,7 @@
       "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-promise": {
@@ -1611,7 +1611,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -1619,7 +1619,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "is-utf8": {
@@ -1663,8 +1663,8 @@
       "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json-schema-traverse": {
@@ -1685,8 +1685,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -1695,11 +1695,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "locate-path": {
@@ -1708,8 +1708,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -1741,8 +1741,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -1750,7 +1750,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "requires": {
-        "yallist": "3.0.3"
+        "yallist": "^3.0.2"
       }
     },
     "map-obj": {
@@ -1770,16 +1770,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.5.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "merge-descriptors": {
@@ -1822,7 +1822,7 @@
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1882,12 +1882,12 @@
       "integrity": "sha1-wDpJLFF+0xU2k/kILkbDBMUipI0=",
       "dev": true,
       "requires": {
-        "dateformat": "1.0.12",
-        "dynamic-dedupe": "0.3.0",
-        "filewatcher": "3.0.1",
-        "minimist": "1.2.0",
-        "node-notifier": "5.4.1",
-        "resolve": "1.11.0"
+        "dateformat": "~1.0.4-1.2.3",
+        "dynamic-dedupe": "^0.3.0",
+        "filewatcher": "~3.0.0",
+        "minimist": "^1.1.3",
+        "node-notifier": "^5.4.0",
+        "resolve": "^1.0.0"
       }
     },
     "node-fetch": {
@@ -1901,11 +1901,11 @@
       "integrity": "sha1-fAGSzGOu2yXNmWGRdNqieQKxCQM=",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "is-wsl": "1.1.0",
-        "semver": "5.7.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.1"
+        "growly": "^1.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "normalize-package-data": {
@@ -1914,10 +1914,10 @@
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "resolve": "1.11.0",
-        "semver": "5.7.0",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "number-is-nan": {
@@ -1946,8 +1946,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.values": {
@@ -1956,10 +1956,10 @@
       "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "on-finished": {
@@ -1976,7 +1976,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1985,7 +1985,7 @@
       "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
       "dev": true,
       "requires": {
-        "mimic-fn": "2.1.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optionator": {
@@ -1994,12 +1994,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-tmpdir": {
@@ -2014,7 +2014,7 @@
       "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -2023,7 +2023,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -2038,7 +2038,7 @@
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "requires": {
-        "callsites": "3.1.0"
+        "callsites": "^3.0.0"
       }
     },
     "parse-json": {
@@ -2047,7 +2047,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parseurl": {
@@ -2061,7 +2061,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -2093,9 +2093,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pify": {
@@ -2116,7 +2116,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -2125,7 +2125,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -2134,7 +2134,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -2157,7 +2157,7 @@
       "integrity": "sha1-0j1B/hN1ZG3i0BBNNFSjAIgCz3s=",
       "dev": true,
       "requires": {
-        "fast-diff": "1.2.0"
+        "fast-diff": "^1.1.2"
       }
     },
     "progress": {
@@ -2171,19 +2171,19 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/protobufjs/-/protobufjs-6.8.8.tgz",
       "integrity": "sha1-yLTxKC/XqQ5vWxCe0RyEr4KQjnw=",
       "requires": {
-        "@protobufjs/aspromise": "1.1.2",
-        "@protobufjs/base64": "1.1.2",
-        "@protobufjs/codegen": "2.0.4",
-        "@protobufjs/eventemitter": "1.1.0",
-        "@protobufjs/fetch": "1.1.0",
-        "@protobufjs/float": "1.0.2",
-        "@protobufjs/inquire": "1.1.0",
-        "@protobufjs/path": "1.1.2",
-        "@protobufjs/pool": "1.1.0",
-        "@protobufjs/utf8": "1.1.0",
-        "@types/long": "4.0.0",
-        "@types/node": "10.14.7",
-        "long": "4.0.0"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
       },
       "dependencies": {
         "@types/node": {
@@ -2198,7 +2198,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/proxy-addr/-/proxy-addr-2.0.5.tgz",
       "integrity": "sha1-NMvWSi2B9LH9IedvnwbIpFKZ7jQ=",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
       }
     },
@@ -2235,9 +2235,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.5.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -2246,8 +2246,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "redent": {
@@ -2256,8 +2256,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regexpp": {
@@ -2272,7 +2272,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "resolve": {
@@ -2281,7 +2281,7 @@
       "integrity": "sha1-QBSHC6KWF2uGND1Qtg87UGCc4jI=",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -2296,8 +2296,8 @@
       "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
       "dev": true,
       "requires": {
-        "onetime": "5.1.0",
-        "signal-exit": "3.0.2"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "retry": {
@@ -2311,7 +2311,7 @@
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "dev": true,
       "requires": {
-        "glob": "7.1.4"
+        "glob": "^7.1.3"
       }
     },
     "run-async": {
@@ -2320,7 +2320,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
@@ -2329,7 +2329,7 @@
       "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
       "dev": true,
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -2354,18 +2354,18 @@
       "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.7.2",
+        "http-errors": "~1.7.2",
         "mime": "1.6.0",
         "ms": "2.1.1",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.1",
-        "statuses": "1.5.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "ms": {
@@ -2380,9 +2380,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.3",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
         "send": "0.17.1"
       }
     },
@@ -2396,8 +2396,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -2406,7 +2406,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -2433,9 +2433,9 @@
       "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "astral-regex": "1.0.0",
-        "is-fullwidth-code-point": "2.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -2452,8 +2452,8 @@
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.4"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -2468,8 +2468,8 @@
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.4"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -2500,9 +2500,9 @@
       "integrity": "sha1-uoRtHaqXw8WWFVMIBj4HXtHJmv8=",
       "dev": true,
       "requires": {
-        "emoji-regex": "8.0.0",
-        "is-fullwidth-code-point": "3.0.0",
-        "strip-ansi": "5.2.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^5.2.0"
       }
     },
     "strip-ansi": {
@@ -2511,7 +2511,7 @@
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "dev": true,
       "requires": {
-        "ansi-regex": "4.1.0"
+        "ansi-regex": "^4.1.0"
       }
     },
     "strip-bom": {
@@ -2520,7 +2520,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -2529,7 +2529,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -2543,11 +2543,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
       "integrity": "sha1-kKQi8HcdnDIGkpTAhgivLUf1luw=",
       "requires": {
-        "backo2": "1.0.2",
-        "eventemitter3": "3.1.2",
-        "iterall": "1.2.2",
-        "symbol-observable": "1.2.0",
-        "ws": "5.2.2"
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0"
       },
       "dependencies": {
         "ws": {
@@ -2555,7 +2555,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/ws/-/ws-5.2.2.tgz",
           "integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -2566,7 +2566,7 @@
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "symbol-observable": {
@@ -2580,10 +2580,10 @@
       "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
       "dev": true,
       "requires": {
-        "ajv": "6.10.2",
-        "lodash": "4.17.15",
-        "slice-ansi": "2.1.0",
-        "string-width": "3.1.0"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -2604,9 +2604,9 @@
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -2629,7 +2629,7 @@
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "toidentifier": {
@@ -2648,7 +2648,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/ts-invariant/-/ts-invariant-0.3.3.tgz",
       "integrity": "sha1-tXQrGIXs+eKcMadQMHSA8EXsCxY=",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.3"
       }
     },
     "tslib": {
@@ -2662,7 +2662,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-fest": {
@@ -2677,7 +2677,7 @@
       "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.24"
+        "mime-types": "~2.1.24"
       }
     },
     "unpipe": {
@@ -2691,7 +2691,7 @@
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "util.promisify": {
@@ -2699,8 +2699,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "requires": {
-        "define-properties": "1.1.3",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "utils-merge": {
@@ -2725,8 +2725,8 @@
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.1.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -2740,7 +2740,7 @@
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -2761,7 +2761,7 @@
       "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "ws": {
@@ -2769,7 +2769,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/ws/-/ws-6.2.1.tgz",
       "integrity": "sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=",
       "requires": {
-        "async-limiter": "1.0.0"
+        "async-limiter": "~1.0.0"
       }
     },
     "xtend": {
@@ -2793,8 +2793,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com:443/artifactory/api/npm/npm/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz",
       "integrity": "sha1-reRLEGDMSoAGJ4VuwQucZ/X2Ocg=",
       "requires": {
-        "tslib": "1.9.3",
-        "zen-observable": "0.8.14"
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -9,7 +9,8 @@ const server = new ApolloServer({
   resolvers,
   context: () => {
     const data = fs.readFileSync('./src/pokemon.json')
-    return { pokemon: JSON.parse(data.toString()) }
+    const typeData = fs.readFileSync('./src/types.json')
+    return { pokemon: JSON.parse(data.toString()), types: JSON.parse(typeData.toString()) }
   },
 })
 

--- a/api/src/resolvers.js
+++ b/api/src/resolvers.js
@@ -16,8 +16,17 @@ exports.resolvers = {
       return nextEvolutionIDs.map(id => context.pokemon[id])
     },
   },
+  Types: {
+    types: (parent, args, context, info) => {
+      const types = parent
+      console.log('CONTEXT: ', context.types)
+      console.log('TYPES: ', types)
+      return parent
+    }
+  },
   Query: {
     pokemonMany: (parent, args, context, info) => _.values(context.pokemon),
     pokemonOne: (parent, args, context, info) => context.pokemon[args.id],
+    types: (parent, args, context, info) => _.values(context.types)
   },
 }

--- a/api/src/typeDefs.js
+++ b/api/src/typeDefs.js
@@ -22,8 +22,13 @@ exports.typeDefs = gql`
     next_evolution: [Pokemon!]
   }
 
+  type Types {
+    types: [String!]!
+  }
+
   type Query {
     pokemonMany: [Pokemon!]!
     pokemonOne(id: ID!): Pokemon
+    types: [Types!]!
   }
 `

--- a/api/src/types.json
+++ b/api/src/types.json
@@ -1,0 +1,19 @@
+{
+  "types": [
+    "Bug",
+    "Dragon",
+    "Electric",
+    "Fighting",
+    "Fire",
+    "Flying",
+    "Ghost",
+    "Grass",
+    "Ground",
+    "Ice",
+    "Normal",
+    "Poison",
+    "Psychic",
+    "Rock",
+    "Water"
+  ]
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@apollo/react-common/-/react-common-3.0.1.tgz",
       "integrity": "sha1-nI8UM92t34DkcSWRJqdvFzjdQnM=",
       "requires": {
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0"
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
       }
     },
     "@apollo/react-hooks": {
@@ -18,10 +18,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@apollo/react-hooks/-/react-hooks-3.0.1.tgz",
       "integrity": "sha1-g4ab7dy7BsugXVDM8FCXGR0kWpw=",
       "requires": {
-        "@apollo/react-common": "3.0.1",
-        "@wry/equality": "0.1.9",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0"
+        "@apollo/react-common": "^3.0.1",
+        "@wry/equality": "^0.1.9",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
       }
     },
     "@babel/code-frame": {
@@ -29,7 +29,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "requires": {
-        "@babel/highlight": "7.5.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
@@ -37,20 +37,20 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/core/-/core-7.5.5.tgz",
       "integrity": "sha1-F7JobvDWvFj5Y93daKtml1VYLDA=",
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@babel/generator": "7.5.5",
-        "@babel/helpers": "7.5.5",
-        "@babel/parser": "7.5.5",
-        "@babel/template": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5",
-        "convert-source-map": "1.6.0",
-        "debug": "4.1.1",
-        "json5": "2.1.0",
-        "lodash": "4.17.15",
-        "resolve": "1.12.0",
-        "semver": "5.7.1",
-        "source-map": "0.5.7"
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helpers": "^7.5.5",
+        "@babel/parser": "^7.5.5",
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "semver": {
@@ -65,11 +65,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/generator/-/generator-7.5.5.tgz",
       "integrity": "sha1-hzp/k2o8iUkbQ1NtEiRbYmZk488=",
       "requires": {
-        "@babel/types": "7.5.5",
-        "jsesc": "2.5.2",
-        "lodash": "4.17.15",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "@babel/types": "^7.5.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -77,7 +77,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha1-Mj053QtQ4Qx8Bsp9djjmhk2MXDI=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -85,8 +85,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
       "integrity": "sha1-a2lijf5Ah3mODE7Zjj1Kay+9L18=",
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.1.0",
-        "@babel/types": "7.5.5"
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-builder-react-jsx": {
@@ -94,8 +94,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
       "integrity": "sha1-oayVpdKz6Irl5UhGv0Yu64GzGKQ=",
       "requires": {
-        "@babel/types": "7.5.5",
-        "esutils": "2.0.3"
+        "@babel/types": "^7.3.0",
+        "esutils": "^2.0.0"
       }
     },
     "@babel/helper-call-delegate": {
@@ -103,9 +103,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
       "integrity": "sha1-h8H4yhmtVSpzanonscH8+LH/H0M=",
       "requires": {
-        "@babel/helper-hoist-variables": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/helper-create-class-features-plugin": {
@@ -113,12 +113,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
       "integrity": "sha1-QB8wLI3bwO3Tb3xrKIfY+hEi5aQ=",
       "requires": {
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-member-expression-to-functions": "7.5.5",
-        "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-replace-supers": "7.5.5",
-        "@babel/helper-split-export-declaration": "7.4.4"
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4"
       }
     },
     "@babel/helper-define-map": {
@@ -126,9 +126,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
       "integrity": "sha1-PewywgRvN+CbKMk+sLED/Sol02k=",
       "requires": {
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/types": "7.5.5",
-        "lodash": "4.17.15"
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -136,8 +136,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha1-U3+hP28WdN90WwwA7I/k6ZaByPY=",
       "requires": {
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-function-name": {
@@ -145,9 +145,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0",
-        "@babel/template": "7.4.4",
-        "@babel/types": "7.5.5"
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -155,7 +155,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -163,7 +163,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
       "integrity": "sha1-Api18lyMCcUxAtUqxKmPdz6yhQo=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -171,7 +171,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
       "integrity": "sha1-H7W47ERTqTxDnun+Ou6kqEt2tZA=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-module-imports": {
@@ -179,7 +179,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha1-lggbcRHkhtpNLNlxrRpP4hbMLj0=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-module-transforms": {
@@ -187,12 +187,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
       "integrity": "sha1-+E/4oJA43Lyh/UNVZhpQCTcWW0o=",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@babel/helper-simple-access": "7.1.0",
-        "@babel/helper-split-export-declaration": "7.4.4",
-        "@babel/template": "7.4.4",
-        "@babel/types": "7.5.5",
-        "lodash": "4.17.15"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -200,7 +200,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha1-opIMVwKwc8Fd5REGIAqoytIEl9U=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -213,7 +213,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
       "integrity": "sha1-CqaCT3EAouDonBUnwjk2wVLKs1E=",
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -221,11 +221,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
       "integrity": "sha1-Nh2AghtvONp1vT8HheziCojF/n8=",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0",
-        "@babel/helper-wrap-function": "7.2.0",
-        "@babel/template": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-replace-supers": {
@@ -233,10 +233,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
       "integrity": "sha1-+EzkPfAxIi0rrQaNJibLV5nDS8I=",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.5.5",
-        "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/helper-simple-access": {
@@ -244,8 +244,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
       "integrity": "sha1-Ze65VMjCRb6qToWdphiPOdceWFw=",
       "requires": {
-        "@babel/template": "7.4.4",
-        "@babel/types": "7.5.5"
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -253,7 +253,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/helper-wrap-function": {
@@ -261,10 +261,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
       "integrity": "sha1-xOABJEV2nigVtVKW6tQ6lYVJ9vo=",
       "requires": {
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/template": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.2.0"
       }
     },
     "@babel/helpers": {
@@ -272,9 +272,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/helpers/-/helpers-7.5.5.tgz",
       "integrity": "sha1-Y5CNKnOUIinR5mhbwqDnMN3jt14=",
       "requires": {
-        "@babel/template": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
       }
     },
     "@babel/highlight": {
@@ -282,9 +282,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
       "requires": {
-        "chalk": "2.4.2",
-        "esutils": "2.0.3",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
@@ -297,9 +297,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
       "integrity": "sha1-somzBmadzkrSCwJSiJoVdoydQX4=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-remap-async-to-generator": "7.1.0",
-        "@babel/plugin-syntax-async-generators": "7.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.2.0"
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -307,8 +307,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
       "integrity": "sha1-qXTPrh43wxEOcfPGouSLjnGVjNQ=",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "7.5.5",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-create-class-features-plugin": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-decorators": {
@@ -316,9 +316,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz",
       "integrity": "sha1-3psqGoqwGW83jiqC8QtuKjbyHMA=",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "7.5.5",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-decorators": "7.2.0"
+        "@babel/helper-create-class-features-plugin": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-decorators": "^7.2.0"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
@@ -326,8 +326,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
       "integrity": "sha1-5TIgLbSDhyNpGxCme4zlCeOXxQY=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-dynamic-import": "7.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -335,8 +335,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
       "integrity": "sha1-Vo7MRGxhSK5rJn8CVREwiR4p8xc=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-json-strings": "7.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-json-strings": "^7.2.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -344,8 +344,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
       "integrity": "sha1-YZOXRPcbp2o65Gte6hilTBbSLlg=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "7.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -353,8 +353,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha1-E12B7baKCB5V5W7EhUHs6AZcOPU=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "7.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -362,9 +362,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
       "integrity": "sha1-UB/9mCbAuR2iJpByByKsfLHKnHg=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-regex": "7.5.5",
-        "regexpu-core": "4.5.5"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -372,7 +372,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha1-aeHw2zTG9aDPfiszI78VmnbIy38=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-decorators": {
@@ -380,7 +380,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
       "integrity": "sha1-xQsblX3MaeSxEntl4cM+72FXDBs=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -388,7 +388,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha1-acFZ/69JmBIhYa2OvF5tH1XfhhI=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-flow": {
@@ -396,7 +396,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
       "integrity": "sha1-p2XwYfgDvEjyQMJvh0f6+Xwmv3w=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -404,7 +404,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
       "integrity": "sha1-cr0T9v/h0lk4Ep0qGGsR/WKVFHA=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-jsx": {
@@ -412,7 +412,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
       "integrity": "sha1-C4WjtLx830zEuL8jYzW5B8oi58c=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -420,7 +420,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -428,7 +428,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha1-qUAT1u2okI3+akd+f57ahWVuz1w=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-syntax-typescript": {
@@ -436,7 +436,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
       "integrity": "sha1-p8w/ZhGan36+LeU4PM4ZNHPWWZE=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -444,7 +444,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
       "integrity": "sha1-mur75Nb/xlY7+Pg3IJFijwB3lVA=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -452,9 +452,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
       "integrity": "sha1-iaOEigFmYjtbxIEWS1k2q5R+iH4=",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-remap-async-to-generator": "7.1.0"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -462,7 +462,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
       "integrity": "sha1-XTzBHo1d3XUqpkyRSNDbbLef0ZA=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -470,8 +470,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz",
       "integrity": "sha1-o185XlQCgi8Q0hGfb44EXjY5os4=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "lodash": "4.17.15"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -479,14 +479,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
       "integrity": "sha1-0JQpnZvWgKFKKg7a44MFrWD7Tek=",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0",
-        "@babel/helper-define-map": "7.5.5",
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-optimise-call-expression": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-replace-supers": "7.5.5",
-        "@babel/helper-split-export-declaration": "7.4.4",
-        "globals": "11.12.0"
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -494,7 +494,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
       "integrity": "sha1-g6ffamWIZbHI9kHVEMbzryICFto=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -502,7 +502,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz",
       "integrity": "sha1-9sCf3+P5RRb/B0/od9t7ye8FhVo=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -510,9 +510,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
       "integrity": "sha1-NhoUi8lRREMSxpRG127R6o5EUMM=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-regex": "7.5.5",
-        "regexpu-core": "4.5.5"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -520,7 +520,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
       "integrity": "sha1-xdv1EGv4TN9pEiLAl0wSsd+TGFM=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -528,8 +528,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
       "integrity": "sha1-pjhoKJ5bQAf3BU1GSRr1FDV2YAg=",
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
@@ -537,8 +537,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz",
       "integrity": "sha1-0meggfSahwX8kUbeB2jGtY3M2Pc=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-flow": "7.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.2.0"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -546,7 +546,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
       "integrity": "sha1-Amf8c14kyAi6FzhmxsTRRA/DxVY=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -554,8 +554,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
       "integrity": "sha1-4UNhFquwYQwiWQlISHVKxSMJIq0=",
       "requires": {
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -563,7 +563,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
       "integrity": "sha1-aQNT6B+SZ9rU/Yz9d+r6hqulPqE=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
@@ -571,7 +571,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
       "integrity": "sha1-+hCqXFiiy2r88sn/qMtNiz1Imi0=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -579,9 +579,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
       "integrity": "sha1-7wBDXUbaCllhqnKKHS7P8GPk+5E=",
       "requires": {
-        "@babel/helper-module-transforms": "7.5.5",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "babel-plugin-dynamic-import-node": "2.3.0"
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -589,10 +589,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
       "integrity": "sha1-QlEn5gRSMTYIWO6qR6cdde3tenQ=",
       "requires": {
-        "@babel/helper-module-transforms": "7.5.5",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-simple-access": "7.1.0",
-        "babel-plugin-dynamic-import-node": "2.3.0"
+        "@babel/helper-module-transforms": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -600,9 +600,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
       "integrity": "sha1-51JmoT75QgLbKgYgl3dW9R1S0kk=",
       "requires": {
-        "@babel/helper-hoist-variables": "7.4.4",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "babel-plugin-dynamic-import-node": "2.3.0"
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -610,8 +610,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
       "integrity": "sha1-dnjOdRafCHe46yI1U4wHQmjdAa4=",
       "requires": {
-        "@babel/helper-module-transforms": "7.5.5",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
@@ -619,7 +619,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz",
       "integrity": "sha1-nSaf0oo3AlgZm0KUc2gTpgu90QY=",
       "requires": {
-        "regexp-tree": "0.1.11"
+        "regexp-tree": "^0.1.6"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -627,7 +627,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
       "integrity": "sha1-GNEgQ4sMye6VpH8scryXaPvtYKU=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -635,8 +635,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
       "integrity": "sha1-xwAh34NAc8ZethO4Z5zEo4HRqfk=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-replace-supers": "7.5.5"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -644,9 +644,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
       "integrity": "sha1-dVbPA/MYvScZ/kySLS2Ai+VXHhY=",
       "requires": {
-        "@babel/helper-call-delegate": "7.4.4",
-        "@babel/helper-get-function-arity": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-call-delegate": "^7.4.4",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-property-literals": {
@@ -654,7 +654,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
       "integrity": "sha1-A+M/ZT9bJcTrVyyYuUhQVbOJ6QU=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-react-constant-elements": {
@@ -662,8 +662,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.5.0.tgz",
       "integrity": "sha1-TWrkAzvDj4pl38orYjXERSKkIvw=",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -671,7 +671,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
       "integrity": "sha1-6/rth4NM6NxCeWCaTwwyTBVuPrA=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-react-jsx": {
@@ -679,9 +679,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
       "integrity": "sha1-8sq5kCZjHHZ+J0WlNoszHP6PUpA=",
       "requires": {
-        "@babel/helper-builder-react-jsx": "7.3.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-jsx": "7.2.0"
+        "@babel/helper-builder-react-jsx": "^7.3.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
@@ -689,8 +689,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
       "integrity": "sha1-Rh4hrZR48QMd1eJ2EI0CfxtSQLo=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-jsx": "7.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
@@ -698,8 +698,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
       "integrity": "sha1-WDsQxJzwV+I3CFvL2MyWC9g72Ws=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-jsx": "7.2.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -707,7 +707,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
       "integrity": "sha1-Yp3IJRLFXO4BNB+ye9/LIQNUaA8=",
       "requires": {
-        "regenerator-transform": "0.14.1"
+        "regenerator-transform": "^0.14.0"
       }
     },
     "@babel/plugin-transform-reserved-words": {
@@ -715,7 +715,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
       "integrity": "sha1-R5Kvh8mYpJNnWX0H/t8CY20uFjQ=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-runtime": {
@@ -723,10 +723,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
       "integrity": "sha1-pjMa+/xZGJ0hNbLglHRFeo49KLw=",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "resolve": "1.12.0",
-        "semver": "5.7.1"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
       },
       "dependencies": {
         "semver": {
@@ -741,7 +741,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
       "integrity": "sha1-YzOu4vjW7n4oYVRXKYk0o7RhmPA=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -749,7 +749,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
       "integrity": "sha1-MQOpq+IvdCttQG7NPNSbd0kZtAY=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -757,8 +757,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
       "integrity": "sha1-oeRUtZlVYKnB4NU338FQYf0mh+E=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-regex": "7.5.5"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -766,8 +766,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
       "integrity": "sha1-nSj+p7vOY3+3YSoHUJidgyHUvLA=",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -775,7 +775,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
       "integrity": "sha1-EX0rzsL79ktLWdH5gZiUaC0p8rI=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0"
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-typescript": {
@@ -783,9 +783,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.5.tgz",
       "integrity": "sha1-bYYnZvCbLaHLH31QX+Ku2ra31Lg=",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "7.5.5",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-syntax-typescript": "7.3.3"
+        "@babel/helper-create-class-features-plugin": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.2.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -793,9 +793,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
       "integrity": "sha1-q0Y0u08U02cov1l4Mis1WHeHlw8=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/helper-regex": "7.5.5",
-        "regexpu-core": "4.5.5"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.5.4"
       }
     },
     "@babel/preset-env": {
@@ -803,56 +803,56 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/preset-env/-/preset-env-7.5.5.tgz",
       "integrity": "sha1-vEcLU6yqSN9LjbJKVw1tof71PJo=",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "7.2.0",
-        "@babel/plugin-proposal-dynamic-import": "7.5.0",
-        "@babel/plugin-proposal-json-strings": "7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "7.5.5",
-        "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "7.4.4",
-        "@babel/plugin-syntax-async-generators": "7.2.0",
-        "@babel/plugin-syntax-dynamic-import": "7.2.0",
-        "@babel/plugin-syntax-json-strings": "7.2.0",
-        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
-        "@babel/plugin-syntax-optional-catch-binding": "7.2.0",
-        "@babel/plugin-transform-arrow-functions": "7.2.0",
-        "@babel/plugin-transform-async-to-generator": "7.5.0",
-        "@babel/plugin-transform-block-scoped-functions": "7.2.0",
-        "@babel/plugin-transform-block-scoping": "7.5.5",
-        "@babel/plugin-transform-classes": "7.5.5",
-        "@babel/plugin-transform-computed-properties": "7.2.0",
-        "@babel/plugin-transform-destructuring": "7.5.0",
-        "@babel/plugin-transform-dotall-regex": "7.4.4",
-        "@babel/plugin-transform-duplicate-keys": "7.5.0",
-        "@babel/plugin-transform-exponentiation-operator": "7.2.0",
-        "@babel/plugin-transform-for-of": "7.4.4",
-        "@babel/plugin-transform-function-name": "7.4.4",
-        "@babel/plugin-transform-literals": "7.2.0",
-        "@babel/plugin-transform-member-expression-literals": "7.2.0",
-        "@babel/plugin-transform-modules-amd": "7.5.0",
-        "@babel/plugin-transform-modules-commonjs": "7.5.0",
-        "@babel/plugin-transform-modules-systemjs": "7.5.0",
-        "@babel/plugin-transform-modules-umd": "7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "7.4.5",
-        "@babel/plugin-transform-new-target": "7.4.4",
-        "@babel/plugin-transform-object-super": "7.5.5",
-        "@babel/plugin-transform-parameters": "7.4.4",
-        "@babel/plugin-transform-property-literals": "7.2.0",
-        "@babel/plugin-transform-regenerator": "7.4.5",
-        "@babel/plugin-transform-reserved-words": "7.2.0",
-        "@babel/plugin-transform-shorthand-properties": "7.2.0",
-        "@babel/plugin-transform-spread": "7.2.2",
-        "@babel/plugin-transform-sticky-regex": "7.2.0",
-        "@babel/plugin-transform-template-literals": "7.4.4",
-        "@babel/plugin-transform-typeof-symbol": "7.2.0",
-        "@babel/plugin-transform-unicode-regex": "7.4.4",
-        "@babel/types": "7.5.5",
-        "browserslist": "4.6.6",
-        "core-js-compat": "3.2.1",
-        "invariant": "2.2.4",
-        "js-levenshtein": "1.1.6",
-        "semver": "5.7.1"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
+        "@babel/plugin-proposal-json-strings": "^7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+        "@babel/plugin-syntax-json-strings": "^7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-transform-arrow-functions": "^7.2.0",
+        "@babel/plugin-transform-async-to-generator": "^7.5.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+        "@babel/plugin-transform-block-scoping": "^7.5.5",
+        "@babel/plugin-transform-classes": "^7.5.5",
+        "@babel/plugin-transform-computed-properties": "^7.2.0",
+        "@babel/plugin-transform-destructuring": "^7.5.0",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/plugin-transform-duplicate-keys": "^7.5.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+        "@babel/plugin-transform-for-of": "^7.4.4",
+        "@babel/plugin-transform-function-name": "^7.4.4",
+        "@babel/plugin-transform-literals": "^7.2.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+        "@babel/plugin-transform-modules-amd": "^7.5.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.5.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
+        "@babel/plugin-transform-modules-umd": "^7.2.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
+        "@babel/plugin-transform-new-target": "^7.4.4",
+        "@babel/plugin-transform-object-super": "^7.5.5",
+        "@babel/plugin-transform-parameters": "^7.4.4",
+        "@babel/plugin-transform-property-literals": "^7.2.0",
+        "@babel/plugin-transform-regenerator": "^7.4.5",
+        "@babel/plugin-transform-reserved-words": "^7.2.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+        "@babel/plugin-transform-spread": "^7.2.0",
+        "@babel/plugin-transform-sticky-regex": "^7.2.0",
+        "@babel/plugin-transform-template-literals": "^7.4.4",
+        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+        "@babel/plugin-transform-unicode-regex": "^7.4.4",
+        "@babel/types": "^7.5.5",
+        "browserslist": "^4.6.0",
+        "core-js-compat": "^3.1.1",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.5.0"
       },
       "dependencies": {
         "semver": {
@@ -867,11 +867,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/preset-react/-/preset-react-7.0.0.tgz",
       "integrity": "sha1-6GtLPZlDPHs+npF0fiZTlYvGs8A=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-transform-react-display-name": "7.2.0",
-        "@babel/plugin-transform-react-jsx": "7.3.0",
-        "@babel/plugin-transform-react-jsx-self": "7.2.0",
-        "@babel/plugin-transform-react-jsx-source": "7.5.0"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
     "@babel/preset-typescript": {
@@ -879,8 +879,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
       "integrity": "sha1-iGaZEQU/oWsrJ26i7eLKYDs/MHo=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "@babel/plugin-transform-typescript": "7.5.5"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.3.2"
       }
     },
     "@babel/runtime": {
@@ -888,7 +888,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.5.5.tgz",
       "integrity": "sha1-dPulbTXvvspEQJHHhQzNSU/S8TI=",
       "requires": {
-        "regenerator-runtime": "0.13.3"
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
@@ -896,9 +896,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@babel/parser": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/traverse": {
@@ -906,15 +906,15 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/traverse/-/traverse-7.5.5.tgz",
       "integrity": "sha1-9mT482jtMpiM1kjan3LVynDxZbs=",
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@babel/generator": "7.5.5",
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-split-export-declaration": "7.4.4",
-        "@babel/parser": "7.5.5",
-        "@babel/types": "7.5.5",
-        "debug": "4.1.1",
-        "globals": "11.12.0",
-        "lodash": "4.17.15"
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
@@ -922,9 +922,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@babel/types/-/types-7.5.5.tgz",
       "integrity": "sha1-l7n3KOGCeFkJqkq1YmTwkKAo0Yo=",
       "requires": {
-        "esutils": "2.0.3",
-        "lodash": "4.17.15",
-        "to-fast-properties": "2.0.0"
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@cnakazawa/watch": {
@@ -932,8 +932,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@cnakazawa/watch/-/watch-1.0.3.tgz",
       "integrity": "sha1-CZE56ux+vweifBeGo/9k85Rk0u8=",
       "requires": {
-        "exec-sh": "0.3.2",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
       }
     },
     "@csstools/convert-colors": {
@@ -989,10 +989,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@hapi/joi/-/joi-15.1.1.tgz",
       "integrity": "sha1-xnW4pxKW8Cgz+NbSQ7NMV7jOGdc=",
       "requires": {
-        "@hapi/address": "2.0.0",
-        "@hapi/bourne": "1.3.2",
-        "@hapi/hoek": "8.2.1",
-        "@hapi/topo": "3.1.3"
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
       }
     },
     "@hapi/topo": {
@@ -1000,7 +1000,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@hapi/topo/-/topo-3.1.3.tgz",
       "integrity": "sha1-x6AuDZNlltKfGE5tf9wH6LXvzhE=",
       "requires": {
-        "@hapi/hoek": "8.2.1"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@jest/console": {
@@ -1008,9 +1008,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/console/-/console-24.9.0.tgz",
       "integrity": "sha1-ebG8Bvt0qM+wHL3t+UVYSxuXB/A=",
       "requires": {
-        "@jest/source-map": "24.9.0",
-        "chalk": "2.4.2",
-        "slash": "2.0.0"
+        "@jest/source-map": "^24.9.0",
+        "chalk": "^2.0.1",
+        "slash": "^2.0.0"
       }
     },
     "@jest/core": {
@@ -1018,34 +1018,34 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/core/-/core-24.9.0.tgz",
       "integrity": "sha1-LOzNC5MYH5xIUOdPKprUPTUTacQ=",
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/reporters": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "graceful-fs": "4.2.2",
-        "jest-changed-files": "24.9.0",
-        "jest-config": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-resolve-dependencies": "24.9.0",
-        "jest-runner": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "jest-watcher": "24.9.0",
-        "micromatch": "3.1.10",
-        "p-each-series": "1.0.0",
-        "realpath-native": "1.1.0",
-        "rimraf": "2.6.3",
-        "slash": "2.0.0",
-        "strip-ansi": "5.2.0"
+        "@jest/console": "^24.7.1",
+        "@jest/reporters": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-changed-files": "^24.9.0",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-resolve-dependencies": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "jest-watcher": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "p-each-series": "^1.0.0",
+        "realpath-native": "^1.1.0",
+        "rimraf": "^2.5.4",
+        "slash": "^2.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -1058,11 +1058,11 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.9.0.tgz",
           "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
           "requires": {
-            "@jest/types": "24.9.0",
-            "browser-resolve": "1.11.3",
-            "chalk": "2.4.2",
-            "jest-pnp-resolver": "1.2.1",
-            "realpath-native": "1.1.0"
+            "@jest/types": "^24.9.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
           }
         }
       }
@@ -1072,10 +1072,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/environment/-/environment-24.9.0.tgz",
       "integrity": "sha1-IeOvotZcBYbL1svv4gi6+t5Eqxg=",
       "requires": {
-        "@jest/fake-timers": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "jest-mock": "24.9.0"
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0"
       }
     },
     "@jest/fake-timers": {
@@ -1083,9 +1083,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
       "integrity": "sha1-uj5r8O7NCaY2BJiWQ00wZjZUDJM=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-mock": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0"
       }
     },
     "@jest/reporters": {
@@ -1093,27 +1093,27 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/reporters/-/reporters-24.9.0.tgz",
       "integrity": "sha1-hmYO/44rlmHQQqjpigKLjWMaW0M=",
       "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "glob": "7.1.4",
-        "istanbul-lib-coverage": "2.0.5",
-        "istanbul-lib-instrument": "3.3.0",
-        "istanbul-lib-report": "2.0.8",
-        "istanbul-lib-source-maps": "3.0.6",
-        "istanbul-reports": "2.2.6",
-        "jest-haste-map": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-worker": "24.9.0",
-        "node-notifier": "5.4.2",
-        "slash": "2.0.0",
-        "source-map": "0.6.1",
-        "string-length": "2.0.0"
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "istanbul-lib-coverage": "^2.0.2",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.1",
+        "istanbul-reports": "^2.2.6",
+        "jest-haste-map": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.6.0",
+        "node-notifier": "^5.4.2",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^2.0.0"
       },
       "dependencies": {
         "jest-resolve": {
@@ -1121,11 +1121,11 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.9.0.tgz",
           "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
           "requires": {
-            "@jest/types": "24.9.0",
-            "browser-resolve": "1.11.3",
-            "chalk": "2.4.2",
-            "jest-pnp-resolver": "1.2.1",
-            "realpath-native": "1.1.0"
+            "@jest/types": "^24.9.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
           }
         },
         "source-map": {
@@ -1140,9 +1140,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/source-map/-/source-map-24.9.0.tgz",
       "integrity": "sha1-DiY6lEML5LQdpoPMwea//ioZFxQ=",
       "requires": {
-        "callsites": "3.1.0",
-        "graceful-fs": "4.2.2",
-        "source-map": "0.6.1"
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.1.15",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "callsites": {
@@ -1162,9 +1162,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/test-result/-/test-result-24.9.0.tgz",
       "integrity": "sha1-EXluiqnb+I6gJXV7MVJZWtBroMo=",
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/istanbul-lib-coverage": "2.0.1"
+        "@jest/console": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/istanbul-lib-coverage": "^2.0.0"
       }
     },
     "@jest/test-sequencer": {
@@ -1172,10 +1172,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
       "integrity": "sha1-+PM081tiWk8vNV8v5+YDba0uazE=",
       "requires": {
-        "@jest/test-result": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-runner": "24.9.0",
-        "jest-runtime": "24.9.0"
+        "@jest/test-result": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0"
       }
     },
     "@jest/transform": {
@@ -1183,21 +1183,21 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/transform/-/transform-24.9.0.tgz",
       "integrity": "sha1-SuJ2iyllU/rasJ6ewRlUPJCxbFY=",
       "requires": {
-        "@babel/core": "7.5.5",
-        "@jest/types": "24.9.0",
-        "babel-plugin-istanbul": "5.2.0",
-        "chalk": "2.4.2",
-        "convert-source-map": "1.6.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "graceful-fs": "4.2.2",
-        "jest-haste-map": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-util": "24.9.0",
-        "micromatch": "3.1.10",
-        "pirates": "4.0.1",
-        "realpath-native": "1.1.0",
-        "slash": "2.0.0",
-        "source-map": "0.6.1",
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^24.9.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "jest-haste-map": "^24.9.0",
+        "jest-regex-util": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "pirates": "^4.0.1",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.1",
         "write-file-atomic": "2.4.1"
       },
       "dependencies": {
@@ -1213,9 +1213,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@jest/types/-/types-24.9.0.tgz",
       "integrity": "sha1-Y8smy3UA0Gnlo4lEGnxqtekJ/Fk=",
       "requires": {
-        "@types/istanbul-lib-coverage": "2.0.1",
-        "@types/istanbul-reports": "1.1.1",
-        "@types/yargs": "13.0.2"
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
       }
     },
     "@material-ui/core": {
@@ -1223,22 +1223,22 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@material-ui/core/-/core-4.3.2.tgz",
       "integrity": "sha1-yiHEwHcDXAoDGS97zvRyjFhN5xs=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "@material-ui/styles": "4.3.0",
-        "@material-ui/system": "4.3.3",
-        "@material-ui/types": "4.1.1",
-        "@material-ui/utils": "4.3.0",
-        "@types/react-transition-group": "4.2.2",
-        "clsx": "1.0.4",
-        "convert-css-length": "2.0.1",
-        "deepmerge": "4.0.0",
-        "hoist-non-react-statics": "3.3.0",
-        "is-plain-object": "3.0.0",
-        "normalize-scroll-left": "0.2.0",
-        "popper.js": "1.15.0",
-        "prop-types": "15.7.2",
-        "react-transition-group": "4.2.2",
-        "warning": "4.0.3"
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.3.0",
+        "@material-ui/system": "^4.3.3",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.3.0",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.2",
+        "convert-css-length": "^2.0.1",
+        "deepmerge": "^4.0.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "is-plain-object": "^3.0.0",
+        "normalize-scroll-left": "^0.2.0",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.0.0",
+        "warning": "^4.0.1"
       },
       "dependencies": {
         "is-plain-object": {
@@ -1246,7 +1246,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-plain-object/-/is-plain-object-3.0.0.tgz",
           "integrity": "sha1-R7/F2htdUNZBEIBsGZNZSC51qSg=",
           "requires": {
-            "isobject": "4.0.0"
+            "isobject": "^4.0.0"
           }
         },
         "isobject": {
@@ -1259,7 +1259,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/warning/-/warning-4.0.3.tgz",
           "integrity": "sha1-Fungd+uKhtavfWSqHgX9hbRnjKM=",
           "requires": {
-            "loose-envify": "1.4.0"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -1269,7 +1269,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@material-ui/icons/-/icons-4.2.1.tgz",
       "integrity": "sha1-/i8cT2DCQlbSRKadhtDADo7UA34=",
       "requires": {
-        "@babel/runtime": "7.5.5"
+        "@babel/runtime": "^7.2.0"
       }
     },
     "@material-ui/styles": {
@@ -1277,14 +1277,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@material-ui/styles/-/styles-4.3.0.tgz",
       "integrity": "sha1-J/EfvwYdiiCtVwOssNuw5pzAA0U=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "@emotion/hash": "0.7.2",
-        "@material-ui/types": "4.1.1",
-        "@material-ui/utils": "4.3.0",
-        "clsx": "1.0.4",
-        "csstype": "2.6.6",
-        "deepmerge": "4.0.0",
-        "hoist-non-react-statics": "3.3.0",
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.7.1",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.1.0",
+        "clsx": "^1.0.2",
+        "csstype": "^2.5.2",
+        "deepmerge": "^4.0.0",
+        "hoist-non-react-statics": "^3.2.1",
         "jss": "10.0.0-alpha.23",
         "jss-plugin-camel-case": "10.0.0-alpha.23",
         "jss-plugin-default-unit": "10.0.0-alpha.23",
@@ -1293,8 +1293,8 @@
         "jss-plugin-props-sort": "10.0.0-alpha.23",
         "jss-plugin-rule-value-function": "10.0.0-alpha.23",
         "jss-plugin-vendor-prefixer": "10.0.0-alpha.23",
-        "prop-types": "15.7.2",
-        "warning": "4.0.3"
+        "prop-types": "^15.7.2",
+        "warning": "^4.0.1"
       },
       "dependencies": {
         "warning": {
@@ -1302,7 +1302,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/warning/-/warning-4.0.3.tgz",
           "integrity": "sha1-Fungd+uKhtavfWSqHgX9hbRnjKM=",
           "requires": {
-            "loose-envify": "1.4.0"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -1312,10 +1312,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@material-ui/system/-/system-4.3.3.tgz",
       "integrity": "sha1-hTT+dq29OTio3qgz5p2Ep6FD7P8=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "deepmerge": "4.0.0",
-        "prop-types": "15.7.2",
-        "warning": "4.0.3"
+        "@babel/runtime": "^7.4.4",
+        "deepmerge": "^4.0.0",
+        "prop-types": "^15.7.2",
+        "warning": "^4.0.1"
       },
       "dependencies": {
         "warning": {
@@ -1323,7 +1323,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/warning/-/warning-4.0.3.tgz",
           "integrity": "sha1-Fungd+uKhtavfWSqHgX9hbRnjKM=",
           "requires": {
-            "loose-envify": "1.4.0"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -1333,7 +1333,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@material-ui/types/-/types-4.1.1.tgz",
       "integrity": "sha1-tl4ALZJgiZcKMnEhOjrXohsX8Cs=",
       "requires": {
-        "@types/react": "16.9.2"
+        "@types/react": "*"
       }
     },
     "@material-ui/utils": {
@@ -1341,9 +1341,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@material-ui/utils/-/utils-4.3.0.tgz",
       "integrity": "sha1-6n8JgVx5LoDycO+LkWUXw/nKuhM=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "prop-types": "15.7.2",
-        "react-is": "16.9.0"
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1351,8 +1351,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -1365,11 +1365,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@reach/router/-/router-1.2.1.tgz",
       "integrity": "sha1-NK41QaWsRPp3luVQal1ydKFivk4=",
       "requires": {
-        "create-react-context": "0.2.3",
-        "invariant": "2.2.4",
-        "prop-types": "15.7.2",
-        "react-lifecycles-compat": "3.0.4",
-        "warning": "3.0.0"
+        "create-react-context": "^0.2.1",
+        "invariant": "^2.2.3",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "warning": "^3.0.0"
       }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
@@ -1417,14 +1417,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@svgr/babel-preset/-/babel-preset-4.3.1.tgz",
       "integrity": "sha1-Yv/LhddWWA6M5gjp0qw7kGO+nig=",
       "requires": {
-        "@svgr/babel-plugin-add-jsx-attribute": "4.2.0",
-        "@svgr/babel-plugin-remove-jsx-attribute": "4.2.0",
-        "@svgr/babel-plugin-remove-jsx-empty-expression": "4.2.0",
-        "@svgr/babel-plugin-replace-jsx-attribute-value": "4.2.0",
-        "@svgr/babel-plugin-svg-dynamic-title": "4.3.1",
-        "@svgr/babel-plugin-svg-em-dimensions": "4.2.0",
-        "@svgr/babel-plugin-transform-react-native-svg": "4.2.0",
-        "@svgr/babel-plugin-transform-svg-component": "4.2.0"
+        "@svgr/babel-plugin-add-jsx-attribute": "^4.2.0",
+        "@svgr/babel-plugin-remove-jsx-attribute": "^4.2.0",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "^4.2.0",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "^4.2.0",
+        "@svgr/babel-plugin-svg-dynamic-title": "^4.3.1",
+        "@svgr/babel-plugin-svg-em-dimensions": "^4.2.0",
+        "@svgr/babel-plugin-transform-react-native-svg": "^4.2.0",
+        "@svgr/babel-plugin-transform-svg-component": "^4.2.0"
       }
     },
     "@svgr/core": {
@@ -1432,9 +1432,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@svgr/core/-/core-4.3.2.tgz",
       "integrity": "sha1-k5yJvmcK15t2L0wGPyE/DgJTXy4=",
       "requires": {
-        "@svgr/plugin-jsx": "4.3.2",
-        "camelcase": "5.3.1",
-        "cosmiconfig": "5.2.1"
+        "@svgr/plugin-jsx": "^4.3.2",
+        "camelcase": "^5.3.1",
+        "cosmiconfig": "^5.2.1"
       }
     },
     "@svgr/hast-util-to-babel-ast": {
@@ -1442,7 +1442,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.3.2.tgz",
       "integrity": "sha1-HVoIL3uSnvjx9XiVAjj2MOFFMrg=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.4.4"
       }
     },
     "@svgr/plugin-jsx": {
@@ -1450,10 +1450,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@svgr/plugin-jsx/-/plugin-jsx-4.3.2.tgz",
       "integrity": "sha1-zp3a/IzddNqITJ968BSvzzf5PTw=",
       "requires": {
-        "@babel/core": "7.5.5",
-        "@svgr/babel-preset": "4.3.1",
-        "@svgr/hast-util-to-babel-ast": "4.3.2",
-        "svg-parser": "2.0.2"
+        "@babel/core": "^7.4.5",
+        "@svgr/babel-preset": "^4.3.1",
+        "@svgr/hast-util-to-babel-ast": "^4.3.2",
+        "svg-parser": "^2.0.0"
       }
     },
     "@svgr/plugin-svgo": {
@@ -1461,9 +1461,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@svgr/plugin-svgo/-/plugin-svgo-4.3.1.tgz",
       "integrity": "sha1-2qwKPYcuP1WTXGWI3TcDNoZenjI=",
       "requires": {
-        "cosmiconfig": "5.2.1",
-        "merge-deep": "3.0.2",
-        "svgo": "1.3.0"
+        "cosmiconfig": "^5.2.1",
+        "merge-deep": "^3.0.2",
+        "svgo": "^1.2.2"
       }
     },
     "@svgr/webpack": {
@@ -1471,14 +1471,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@svgr/webpack/-/webpack-4.3.2.tgz",
       "integrity": "sha1-MZ1Eccjz1cOvNQWSdINNm1uPuVY=",
       "requires": {
-        "@babel/core": "7.5.5",
-        "@babel/plugin-transform-react-constant-elements": "7.5.0",
-        "@babel/preset-env": "7.5.5",
-        "@babel/preset-react": "7.0.0",
-        "@svgr/core": "4.3.2",
-        "@svgr/plugin-jsx": "4.3.2",
-        "@svgr/plugin-svgo": "4.3.1",
-        "loader-utils": "1.2.3"
+        "@babel/core": "^7.4.5",
+        "@babel/plugin-transform-react-constant-elements": "^7.0.0",
+        "@babel/preset-env": "^7.4.5",
+        "@babel/preset-react": "^7.0.0",
+        "@svgr/core": "^4.3.2",
+        "@svgr/plugin-jsx": "^4.3.2",
+        "@svgr/plugin-svgo": "^4.3.1",
+        "loader-utils": "^1.2.3"
       }
     },
     "@types/babel__core": {
@@ -1486,11 +1486,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/babel__core/-/babel__core-7.1.2.tgz",
       "integrity": "sha1-YIx09VkoAz/OGLmbITwWvks9EU8=",
       "requires": {
-        "@babel/parser": "7.5.5",
-        "@babel/types": "7.5.5",
-        "@types/babel__generator": "7.0.2",
-        "@types/babel__template": "7.0.2",
-        "@types/babel__traverse": "7.0.7"
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
       }
     },
     "@types/babel__generator": {
@@ -1498,7 +1498,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/babel__generator/-/babel__generator-7.0.2.tgz",
       "integrity": "sha1-0hEqayH61gDXZ0J0KTyF3ODLR/w=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
@@ -1506,8 +1506,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/babel__template/-/babel__template-7.0.2.tgz",
       "integrity": "sha1-T/Y9a1Lt2sHee5daUiPtMuzqkwc=",
       "requires": {
-        "@babel/parser": "7.5.5",
-        "@babel/types": "7.5.5"
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__traverse": {
@@ -1515,7 +1515,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
       "integrity": "sha1-JJbp/1YZbMFCnHIDTgfqthIbbz8=",
       "requires": {
-        "@babel/types": "7.5.5"
+        "@babel/types": "^7.3.0"
       }
     },
     "@types/eslint-visitor-keys": {
@@ -1533,7 +1533,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha1-5Ucef6M8YTWN04QmGJwDelhDO4w=",
       "requires": {
-        "@types/istanbul-lib-coverage": "2.0.1"
+        "@types/istanbul-lib-coverage": "*"
       }
     },
     "@types/istanbul-reports": {
@@ -1541,8 +1541,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha1-eoy/akBvNsit2HFiWyeOrwsNJVo=",
       "requires": {
-        "@types/istanbul-lib-coverage": "2.0.1",
-        "@types/istanbul-lib-report": "1.1.1"
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
       }
     },
     "@types/json-schema": {
@@ -1570,8 +1570,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/react/-/react-16.9.2.tgz",
       "integrity": "sha1-bRdlQxoa0Yd5eQE5BnMarjc94mg=",
       "requires": {
-        "@types/prop-types": "15.7.1",
-        "csstype": "2.6.6"
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
       }
     },
     "@types/react-transition-group": {
@@ -1579,7 +1579,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/react-transition-group/-/react-transition-group-4.2.2.tgz",
       "integrity": "sha1-jIUcRZiiOjo0FzBp+0xcnkHALj8=",
       "requires": {
-        "@types/react": "16.9.2"
+        "@types/react": "*"
       }
     },
     "@types/stack-utils": {
@@ -1592,7 +1592,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@types/yargs/-/yargs-13.0.2.tgz",
       "integrity": "sha1-pkZ0/AFJV07NkLp0bpMrWl97NlM=",
       "requires": {
-        "@types/yargs-parser": "13.0.0"
+        "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
@@ -1611,10 +1611,10 @@
       "integrity": "sha1-Iv7ZsW3f60Av17zeVjB4IPbrxJ8=",
       "requires": {
         "@typescript-eslint/experimental-utils": "1.13.0",
-        "eslint-utils": "1.4.0",
-        "functional-red-black-tree": "1.0.1",
-        "regexpp": "2.0.1",
-        "tsutils": "3.17.1"
+        "eslint-utils": "^1.3.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^2.0.1",
+        "tsutils": "^3.7.0"
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -1622,9 +1622,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
       "integrity": "sha1-sIxg14DABn3i+0SwS0MvVAE4MB4=",
       "requires": {
-        "@types/json-schema": "7.0.3",
+        "@types/json-schema": "^7.0.3",
         "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-scope": "4.0.3"
+        "eslint-scope": "^4.0.0"
       }
     },
     "@typescript-eslint/parser": {
@@ -1632,10 +1632,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@typescript-eslint/parser/-/parser-1.13.0.tgz",
       "integrity": "sha1-Yax4EepSeRxH3J/U3UoYT66aw1U=",
       "requires": {
-        "@types/eslint-visitor-keys": "1.0.0",
+        "@types/eslint-visitor-keys": "^1.0.0",
         "@typescript-eslint/experimental-utils": "1.13.0",
         "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-visitor-keys": "1.1.0"
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
@@ -1698,7 +1698,7 @@
       "integrity": "sha1-3vS5knsBAdyMu9jR7bW3ucguskU=",
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
-        "mamacro": "0.0.3"
+        "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
@@ -1722,7 +1722,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
       "integrity": "sha1-cSMp2+8kDza/V70ve4+5v0FUQh4=",
       "requires": {
-        "@xtuc/ieee754": "1.2.0"
+        "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
@@ -1817,8 +1817,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@wry/context/-/context-0.4.4.tgz",
       "integrity": "sha1-5Q9fodbPqr8pd9H9pa6RcX+IFfg=",
       "requires": {
-        "@types/node": "12.7.2",
-        "tslib": "1.10.0"
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
       }
     },
     "@wry/equality": {
@@ -1826,7 +1826,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/@wry/equality/-/equality-0.1.9.tgz",
       "integrity": "sha1-sT4Yt6gFPGhYqmyFtUkR+zHjqQk=",
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.9.3"
       }
     },
     "@xtuc/ieee754": {
@@ -1849,7 +1849,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
       "requires": {
-        "mime-types": "2.1.24",
+        "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
     },
@@ -1863,8 +1863,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/acorn-globals/-/acorn-globals-4.3.3.tgz",
       "integrity": "sha1-qG91tpaAuHgNMO3SHu5ODqFwwF4=",
       "requires": {
-        "acorn": "6.3.0",
-        "acorn-walk": "6.2.0"
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
       }
     },
     "acorn-jsx": {
@@ -1906,10 +1906,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-errors": {
@@ -1937,7 +1937,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
       "integrity": "sha1-TczbhGw+7hD21k3qZic+q5DDcig=",
       "requires": {
-        "type-fest": "0.5.2"
+        "type-fest": "^0.5.2"
       }
     },
     "ansi-html": {
@@ -1955,7 +1955,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -1963,8 +1963,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "apollo-boost": {
@@ -1972,15 +1972,15 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-boost/-/apollo-boost-0.4.4.tgz",
       "integrity": "sha1-fCeNrGy2+j8vcQxWut3G465zBlE=",
       "requires": {
-        "apollo-cache": "1.3.2",
-        "apollo-cache-inmemory": "1.6.3",
-        "apollo-client": "2.6.4",
-        "apollo-link": "1.2.12",
-        "apollo-link-error": "1.1.11",
-        "apollo-link-http": "1.5.15",
-        "graphql-tag": "2.10.1",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0"
+        "apollo-cache": "^1.3.2",
+        "apollo-cache-inmemory": "^1.6.3",
+        "apollo-client": "^2.6.4",
+        "apollo-link": "^1.0.6",
+        "apollo-link-error": "^1.0.3",
+        "apollo-link-http": "^1.3.1",
+        "graphql-tag": "^2.4.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-cache": {
@@ -1988,8 +1988,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-cache/-/apollo-cache-1.3.2.tgz",
       "integrity": "sha1-303OViQNbJXGE1ENfkCfchTm0mo=",
       "requires": {
-        "apollo-utilities": "1.3.2",
-        "tslib": "1.10.0"
+        "apollo-utilities": "^1.3.2",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-cache-inmemory": {
@@ -1997,11 +1997,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.3.tgz",
       "integrity": "sha1-gmhh0guspKvEX3ynqHQQWQW4Ul0=",
       "requires": {
-        "apollo-cache": "1.3.2",
-        "apollo-utilities": "1.3.2",
-        "optimism": "0.10.2",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0"
+        "apollo-cache": "^1.3.2",
+        "apollo-utilities": "^1.3.2",
+        "optimism": "^0.10.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-client": {
@@ -2009,14 +2009,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-client/-/apollo-client-2.6.4.tgz",
       "integrity": "sha1-hywyknJjoNNGVcXviolJ+7ILYUA=",
       "requires": {
-        "@types/zen-observable": "0.8.0",
+        "@types/zen-observable": "^0.8.0",
         "apollo-cache": "1.3.2",
-        "apollo-link": "1.2.12",
+        "apollo-link": "^1.0.0",
         "apollo-utilities": "1.3.2",
-        "symbol-observable": "1.2.0",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0",
-        "zen-observable": "0.8.14"
+        "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     },
     "apollo-link": {
@@ -2024,10 +2024,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-link/-/apollo-link-1.2.12.tgz",
       "integrity": "sha1-AUtRT7qV8ZRcOK1MIW8xvP7mhCk=",
       "requires": {
-        "apollo-utilities": "1.3.2",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0",
-        "zen-observable-ts": "0.8.19"
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.19"
       }
     },
     "apollo-link-error": {
@@ -2035,9 +2035,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-link-error/-/apollo-link-error-1.1.11.tgz",
       "integrity": "sha1-fNNjF5YW+5DaeGbO6FywDuRdLzs=",
       "requires": {
-        "apollo-link": "1.2.12",
-        "apollo-link-http-common": "0.2.14",
-        "tslib": "1.10.0"
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-http": {
@@ -2045,9 +2045,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-link-http/-/apollo-link-http-1.5.15.tgz",
       "integrity": "sha1-EGqyO7iZe9VZZdBYVXNtMxGWUs8=",
       "requires": {
-        "apollo-link": "1.2.12",
-        "apollo-link-http-common": "0.2.14",
-        "tslib": "1.10.0"
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-http-common": {
@@ -2055,9 +2055,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz",
       "integrity": "sha1-06GVwS4A9OMRxBfxIRgdzDH30Mg=",
       "requires": {
-        "apollo-link": "1.2.12",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0"
+        "apollo-link": "^1.2.12",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-utilities": {
@@ -2065,10 +2065,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
       "integrity": "sha1-jL3PiwEvZkzWy1dn9hMPWu2RFck=",
       "requires": {
-        "@wry/equality": "0.1.9",
-        "fast-json-stable-stringify": "2.0.0",
-        "ts-invariant": "0.4.4",
-        "tslib": "1.10.0"
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "aproba": {
@@ -2081,7 +2081,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "aria-query": {
@@ -2090,7 +2090,7 @@
       "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "2.20.0"
+        "commander": "^2.11.0"
       }
     },
     "arity-n": {
@@ -2133,8 +2133,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-map": {
@@ -2152,7 +2152,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -2180,7 +2180,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "asn1.js": {
@@ -2188,9 +2188,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -2251,13 +2251,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/autoprefixer/-/autoprefixer-9.6.1.tgz",
       "integrity": "sha1-UZZ6AtLSMAuwGGbBYR7INI01Wkc=",
       "requires": {
-        "browserslist": "4.6.6",
-        "caniuse-lite": "1.0.30000989",
-        "chalk": "2.4.2",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "4.0.2"
+        "browserslist": "^4.6.3",
+        "caniuse-lite": "^1.0.30000980",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.17",
+        "postcss-value-parser": "^4.0.0"
       },
       "dependencies": {
         "postcss-value-parser": {
@@ -2290,9 +2290,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.3",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2310,11 +2310,11 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "js-tokens": {
@@ -2327,7 +2327,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2342,12 +2342,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-eslint/-/babel-eslint-10.0.2.tgz",
       "integrity": "sha1-GC1awgRXn/CIFoSwQFYP3MFVhFY=",
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@babel/parser": "7.5.5",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
         "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.1.0"
+        "eslint-visitor-keys": "^1.0.0"
       },
       "dependencies": {
         "eslint-scope": {
@@ -2355,8 +2355,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-scope/-/eslint-scope-3.7.1.tgz",
           "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
           "requires": {
-            "esrecurse": "4.2.1",
-            "estraverse": "4.3.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         }
       }
@@ -2366,7 +2366,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
       "integrity": "sha1-Cirt+BQX7TkbheGLRhTmk6A1GiE=",
       "requires": {
-        "babylon": "6.18.0"
+        "babylon": "^6.18.0"
       }
     },
     "babel-jest": {
@@ -2374,13 +2374,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-jest/-/babel-jest-24.9.0.tgz",
       "integrity": "sha1-P8Mny4RnuJ0U17xw4xUQSng8zVQ=",
       "requires": {
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/babel__core": "7.1.2",
-        "babel-plugin-istanbul": "5.2.0",
-        "babel-preset-jest": "24.9.0",
-        "chalk": "2.4.2",
-        "slash": "2.0.0"
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/babel__core": "^7.1.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "babel-preset-jest": "^24.9.0",
+        "chalk": "^2.4.2",
+        "slash": "^2.0.0"
       }
     },
     "babel-loader": {
@@ -2388,10 +2388,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-loader/-/babel-loader-8.0.6.tgz",
       "integrity": "sha1-4zvbbzYrA/S7FBoMIauHxQG3Dfs=",
       "requires": {
-        "find-cache-dir": "2.1.0",
-        "loader-utils": "1.2.3",
-        "mkdirp": "0.5.1",
-        "pify": "4.0.1"
+        "find-cache-dir": "^2.0.0",
+        "loader-utils": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "pify": "^4.0.1"
       },
       "dependencies": {
         "pify": {
@@ -2406,7 +2406,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
       "integrity": "sha1-8A9Qe9qjw+P/bn5emNkKesq5b38=",
       "requires": {
-        "object.assign": "4.1.0"
+        "object.assign": "^4.1.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -2414,10 +2414,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
       "integrity": "sha1-30reg9iXqS3wacTZolzyZxKTyFQ=",
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0",
-        "find-up": "3.0.0",
-        "istanbul-lib-instrument": "3.3.0",
-        "test-exclude": "5.2.3"
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "find-up": "^3.0.0",
+        "istanbul-lib-instrument": "^3.3.0",
+        "test-exclude": "^5.2.3"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -2425,7 +2425,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
       "integrity": "sha1-T4NwketAfgFEfIhDy+xUbQAC11Y=",
       "requires": {
-        "@types/babel__traverse": "7.0.7"
+        "@types/babel__traverse": "^7.0.6"
       }
     },
     "babel-plugin-macros": {
@@ -2433,9 +2433,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",
       "integrity": "sha1-Qffq1hb8NvapMYDolpf2n1FnEYE=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "cosmiconfig": "5.2.1",
-        "resolve": "1.12.0"
+        "@babel/runtime": "^7.4.2",
+        "cosmiconfig": "^5.2.0",
+        "resolve": "^1.10.0"
       }
     },
     "babel-plugin-named-asset-import": {
@@ -2448,10 +2448,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz",
       "integrity": "sha1-+HgpU3URFfrwmp+SQxQ2kSw0AGs=",
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0",
-        "@babel/helper-module-imports": "7.0.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "lodash": "4.17.15"
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-module-imports": "^7.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11"
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -2469,8 +2469,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-react-remove-prop-types": {
@@ -2483,8 +2483,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
       "integrity": "sha1-GStSHiIX+x0fZ89z9wwzZlCtPNw=",
       "requires": {
-        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
-        "babel-plugin-jest-hoist": "24.9.0"
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "babel-plugin-jest-hoist": "^24.9.0"
       }
     },
     "babel-preset-react-app": {
@@ -2515,8 +2515,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.6.9",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "core-js": {
@@ -2546,13 +2546,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.3.0",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.2",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2560,7 +2560,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2568,7 +2568,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2576,7 +2576,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2584,9 +2584,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -2611,7 +2611,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "big.js": {
@@ -2640,15 +2640,15 @@
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "requires": {
         "bytes": "3.1.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.7.0",
         "raw-body": "2.4.0",
-        "type-is": "1.6.18"
+        "type-is": "~1.6.17"
       },
       "dependencies": {
         "bytes": {
@@ -2681,12 +2681,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
-        "array-flatten": "2.1.2",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.2.3",
-        "multicast-dns-service-types": "1.1.0"
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
       }
     },
     "boolbase": {
@@ -2699,7 +2699,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2708,16 +2708,16 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.3",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2725,7 +2725,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2760,12 +2760,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -2773,9 +2773,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -2783,10 +2783,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -2794,8 +2794,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.1.0"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -2803,13 +2803,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.5.0",
-        "inherits": "2.0.4",
-        "parse-asn1": "5.1.4"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -2817,7 +2817,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "requires": {
-        "pako": "1.0.10"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -2825,9 +2825,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/browserslist/-/browserslist-4.6.6.tgz",
       "integrity": "sha1-bkv0Z83lILydvfN0fa+gNTHOxFM=",
       "requires": {
-        "caniuse-lite": "1.0.30000989",
-        "electron-to-chromium": "1.3.232",
-        "node-releases": "1.1.27"
+        "caniuse-lite": "^1.0.30000984",
+        "electron-to-chromium": "^1.3.191",
+        "node-releases": "^1.1.25"
       }
     },
     "bser": {
@@ -2835,7 +2835,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/bser/-/bser-2.1.0.tgz",
       "integrity": "sha1-Zfx4S/f4fACblzwS22VGkC+px7U=",
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "buffer": {
@@ -2843,9 +2843,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.1",
-        "ieee754": "1.1.13",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -2878,21 +2878,21 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cacache/-/cacache-12.0.2.tgz",
       "integrity": "sha1-jbAyBeNgiaPfaVTGbOklQUQaxGw=",
       "requires": {
-        "bluebird": "3.5.5",
-        "chownr": "1.1.2",
-        "figgy-pudding": "3.5.1",
-        "glob": "7.1.4",
-        "graceful-fs": "4.2.2",
-        "infer-owner": "1.0.4",
-        "lru-cache": "5.1.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.3",
-        "ssri": "6.0.1",
-        "unique-filename": "1.1.1",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
       }
     },
     "cache-base": {
@@ -2900,15 +2900,15 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.3.0",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.1",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.1",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "call-me-maybe": {
@@ -2921,7 +2921,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "requires": {
-        "callsites": "2.0.0"
+        "callsites": "^2.0.0"
       }
     },
     "caller-path": {
@@ -2929,7 +2929,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "requires": {
-        "caller-callsite": "2.0.0"
+        "caller-callsite": "^2.0.0"
       }
     },
     "callsites": {
@@ -2942,8 +2942,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -2961,10 +2961,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/caniuse-api/-/caniuse-api-3.0.0.tgz",
       "integrity": "sha1-Xk2Q4idJYdRikZl99Znj7QCO5MA=",
       "requires": {
-        "browserslist": "4.6.6",
-        "caniuse-lite": "1.0.30000989",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
       }
     },
     "caniuse-lite": {
@@ -2977,7 +2977,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/capture-exit/-/capture-exit-2.0.0.tgz",
       "integrity": "sha1-+5U7+uvreB9iiYI52rtCbQilCaQ=",
       "requires": {
-        "rsvp": "4.8.5"
+        "rsvp": "^4.8.4"
       }
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -2995,9 +2995,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -3010,18 +3010,18 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/chokidar/-/chokidar-2.1.6.tgz",
       "integrity": "sha1-tsrWU6kp4kTOioNCRBZNJB+pVMU=",
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.3",
-        "braces": "2.3.2",
-        "fsevents": "1.2.9",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.4",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.1",
-        "normalize-path": "3.0.0",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.2.1",
-        "upath": "1.1.2"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
       },
       "dependencies": {
         "fsevents": {
@@ -3030,8 +3030,8 @@
           "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
           "optional": true,
           "requires": {
-            "nan": "2.14.0",
-            "node-pre-gyp": "0.12.0"
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
           },
           "dependencies": {
             "abbrev": {
@@ -3041,7 +3041,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3053,19 +3054,21 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
               }
             },
@@ -3076,15 +3079,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3096,7 +3102,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "deep-extend": {
@@ -3119,7 +3125,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "fs.realpath": {
@@ -3132,14 +3138,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.3"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               }
             },
             "glob": {
@@ -3147,12 +3153,12 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "has-unicode": {
@@ -3165,7 +3171,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "ignore-walk": {
@@ -3173,7 +3179,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               }
             },
             "inflight": {
@@ -3181,13 +3187,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3197,8 +3204,9 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
@@ -3209,20 +3217,23 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
@@ -3230,12 +3241,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3250,9 +3262,9 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "debug": "4.1.1",
-                "iconv-lite": "0.4.24",
-                "sax": "1.2.4"
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
               }
             },
             "node-pre-gyp": {
@@ -3260,16 +3272,16 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "detect-libc": "1.0.3",
-                "mkdirp": "0.5.1",
-                "needle": "2.3.0",
-                "nopt": "4.0.1",
-                "npm-packlist": "1.4.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.8",
-                "rimraf": "2.6.3",
-                "semver": "5.7.0",
-                "tar": "4.4.8"
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
               }
             },
             "nopt": {
@@ -3277,8 +3289,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "abbrev": "1.1.1",
-                "osenv": "0.1.5"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "npm-bundled": {
@@ -3291,8 +3303,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "ignore-walk": "3.0.1",
-                "npm-bundled": "1.0.6"
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
               }
             },
             "npmlog": {
@@ -3300,15 +3312,16 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "1.1.5",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               }
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3318,8 +3331,9 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-homedir": {
@@ -3337,8 +3351,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "path-is-absolute": {
@@ -3356,10 +3370,10 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -3374,13 +3388,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "rimraf": {
@@ -3388,12 +3402,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3420,28 +3435,30 @@
               "bundled": true,
               "optional": true
             },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.1.2"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "safe-buffer": "~5.1.0"
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
@@ -3454,13 +3471,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "chownr": "1.1.1",
-                "fs-minipass": "1.2.5",
-                "minipass": "2.3.5",
-                "minizlib": "1.2.1",
-                "mkdirp": "0.5.1",
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
               }
             },
             "util-deprecate": {
@@ -3473,16 +3490,18 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -3491,8 +3510,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -3500,7 +3519,7 @@
               "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -3522,7 +3541,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
       "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.9.0"
       }
     },
     "ci-info": {
@@ -3535,8 +3554,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "requires": {
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "class-utils": {
@@ -3544,10 +3563,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -3555,7 +3574,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -3565,7 +3584,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha1-LUEe92uFabbQyEBo2r6FsKpeXBc=",
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "~0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -3580,7 +3599,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
       "requires": {
-        "restore-cursor": "3.1.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
@@ -3593,9 +3612,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "requires": {
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0",
-        "wrap-ansi": "5.1.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -3613,9 +3632,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -3625,11 +3644,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-plain-object": "2.0.4",
-        "kind-of": "3.2.2",
-        "lazy-cache": "1.0.4",
-        "shallow-clone": "0.1.2"
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
       }
     },
     "clsx": {
@@ -3647,9 +3666,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/coa/-/coa-2.0.2.tgz",
       "integrity": "sha1-Q/bCEVG07yv1cYfbDXPeIp4+fsM=",
       "requires": {
-        "@types/q": "1.5.2",
-        "chalk": "2.4.2",
-        "q": "1.5.1"
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -3662,8 +3681,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color": {
@@ -3671,8 +3690,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/color/-/color-3.1.2.tgz",
       "integrity": "sha1-aBSOf4XUGtdknF+oyBBvCY0inhA=",
       "requires": {
-        "color-convert": "1.9.3",
-        "color-string": "1.5.3"
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
@@ -3693,8 +3712,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
       "requires": {
-        "color-name": "1.1.3",
-        "simple-swizzle": "0.2.2"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "combined-stream": {
@@ -3702,7 +3721,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -3730,7 +3749,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/compose-function/-/compose-function-3.0.3.tgz",
       "integrity": "sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=",
       "requires": {
-        "arity-n": "1.0.4"
+        "arity-n": "^1.0.4"
       }
     },
     "compressible": {
@@ -3738,7 +3757,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/compressible/-/compressible-2.0.17.tgz",
       "integrity": "sha1-bowQihatWDhKl386SCyiC/8vOME=",
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": ">= 1.40.0 < 2"
       }
     },
     "compression": {
@@ -3746,13 +3765,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/compression/-/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "2.0.17",
+        "compressible": "~2.0.16",
         "debug": "2.6.9",
-        "on-headers": "1.0.2",
+        "on-headers": "~1.0.2",
         "safe-buffer": "5.1.2",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -3785,10 +3804,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "readable-stream": {
@@ -3796,13 +3815,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -3810,7 +3829,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -3830,7 +3849,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -3866,7 +3885,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "cookie": {
@@ -3884,12 +3903,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.3",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "copy-descriptor": {
@@ -3907,8 +3926,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/core-js-compat/-/core-js-compat-3.2.1.tgz",
       "integrity": "sha1-DL28LjhujgDTuF3IHISO/+xbgVA=",
       "requires": {
-        "browserslist": "4.6.6",
-        "semver": "6.3.0"
+        "browserslist": "^4.6.6",
+        "semver": "^6.3.0"
       }
     },
     "core-util-is": {
@@ -3921,10 +3940,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
       "requires": {
-        "import-fresh": "2.0.0",
-        "is-directory": "0.3.1",
-        "js-yaml": "3.13.1",
-        "parse-json": "4.0.0"
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
       }
     },
     "create-ecdh": {
@@ -3932,8 +3951,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.5.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -3941,11 +3960,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.4",
-        "md5.js": "1.3.5",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -3953,12 +3972,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.4",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-react-context": {
@@ -3966,8 +3985,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/create-react-context/-/create-react-context-0.2.3.tgz",
       "integrity": "sha1-nsFAppFKIu8EuLCbd3HeiVZ8tvM=",
       "requires": {
-        "fbjs": "0.8.17",
-        "gud": "1.0.0"
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -3975,11 +3994,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.7.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "semver": {
@@ -3994,17 +4013,17 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.4",
-        "pbkdf2": "3.0.17",
-        "public-encrypt": "4.0.3",
-        "randombytes": "2.1.0",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "css": {
@@ -4012,10 +4031,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css/-/css-2.2.4.tgz",
       "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
       "requires": {
-        "inherits": "2.0.4",
-        "source-map": "0.6.1",
-        "source-map-resolve": "0.5.2",
-        "urix": "0.1.0"
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -4030,7 +4049,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
       "integrity": "sha1-3979MlS/ioICeZNnTM81SDv8s8U=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.5"
       }
     },
     "css-color-keywords": {
@@ -4048,8 +4067,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
       "integrity": "sha1-wZiUD2OnbX42wecQGLABchBUyyI=",
       "requires": {
-        "postcss": "7.0.17",
-        "timsort": "0.3.0"
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
       }
     },
     "css-has-pseudo": {
@@ -4057,8 +4076,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
       "integrity": "sha1-PGQqs0yiQsWcQaEl35EFhB9pZu4=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "5.0.0"
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^5.0.0-rc.4"
       },
       "dependencies": {
         "cssesc": {
@@ -4071,9 +4090,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
           "requires": {
-            "cssesc": "2.0.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -4083,17 +4102,17 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-loader/-/css-loader-2.1.1.tgz",
       "integrity": "sha1-2CVPcuQSuyI4u0TdZ0/770lzM+o=",
       "requires": {
-        "camelcase": "5.3.1",
-        "icss-utils": "4.1.1",
-        "loader-utils": "1.2.3",
-        "normalize-path": "3.0.0",
-        "postcss": "7.0.17",
-        "postcss-modules-extract-imports": "2.0.0",
-        "postcss-modules-local-by-default": "2.0.6",
-        "postcss-modules-scope": "2.1.0",
-        "postcss-modules-values": "2.0.0",
-        "postcss-value-parser": "3.3.1",
-        "schema-utils": "1.0.0"
+        "camelcase": "^5.2.0",
+        "icss-utils": "^4.1.0",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.14",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^2.0.6",
+        "postcss-modules-scope": "^2.1.0",
+        "postcss-modules-values": "^2.0.0",
+        "postcss-value-parser": "^3.3.0",
+        "schema-utils": "^1.0.0"
       },
       "dependencies": {
         "normalize-path": {
@@ -4108,7 +4127,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
       "integrity": "sha1-b4MKJxQZnU8NDQu4onkW7WXP8fQ=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.5"
       }
     },
     "css-select": {
@@ -4116,10 +4135,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-select/-/css-select-2.0.2.tgz",
       "integrity": "sha1-q0OGzsnh9miFVWSxfDcztDsqXt4=",
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.3",
-        "domutils": "1.7.0",
-        "nth-check": "1.0.2"
+        "boolbase": "^1.0.0",
+        "css-what": "^2.1.2",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
       }
     },
     "css-select-base-adapter": {
@@ -4132,9 +4151,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-to-react-native/-/css-to-react-native-2.3.1.tgz",
       "integrity": "sha1-zw9h4FFIRuLU3BiLCIbinYvvZKI=",
       "requires": {
-        "camelize": "1.0.0",
-        "css-color-keywords": "1.0.0",
-        "postcss-value-parser": "3.3.1"
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "css-tree": {
@@ -4143,7 +4162,7 @@
       "integrity": "sha1-lw4g5akfejeN3Q/FjQtsjU876T4=",
       "requires": {
         "mdn-data": "2.0.4",
-        "source-map": "0.5.7"
+        "source-map": "^0.5.3"
       }
     },
     "css-unit-converter": {
@@ -4156,8 +4175,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-vendor/-/css-vendor-2.0.6.tgz",
       "integrity": "sha1-ogX3PXVi6HKMhu9s5e58fl7v1xs=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "is-in-browser": "1.1.3"
+        "@babel/runtime": "^7.5.5",
+        "is-in-browser": "^1.0.2"
       }
     },
     "css-what": {
@@ -4180,10 +4199,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cssnano/-/cssnano-4.1.10.tgz",
       "integrity": "sha1-CsQfCxPRPUZUh+ERt3jULaYxuLI=",
       "requires": {
-        "cosmiconfig": "5.2.1",
-        "cssnano-preset-default": "4.0.7",
-        "is-resolvable": "1.1.0",
-        "postcss": "7.0.17"
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.7",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "cssnano-preset-default": {
@@ -4191,36 +4210,36 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
       "integrity": "sha1-UexmLM/KD4izltzZZ5zbkxvhf3Y=",
       "requires": {
-        "css-declaration-sorter": "4.0.1",
-        "cssnano-util-raw-cache": "4.0.1",
-        "postcss": "7.0.17",
-        "postcss-calc": "7.0.1",
-        "postcss-colormin": "4.0.3",
-        "postcss-convert-values": "4.0.1",
-        "postcss-discard-comments": "4.0.2",
-        "postcss-discard-duplicates": "4.0.2",
-        "postcss-discard-empty": "4.0.1",
-        "postcss-discard-overridden": "4.0.1",
-        "postcss-merge-longhand": "4.0.11",
-        "postcss-merge-rules": "4.0.3",
-        "postcss-minify-font-values": "4.0.2",
-        "postcss-minify-gradients": "4.0.2",
-        "postcss-minify-params": "4.0.2",
-        "postcss-minify-selectors": "4.0.2",
-        "postcss-normalize-charset": "4.0.1",
-        "postcss-normalize-display-values": "4.0.2",
-        "postcss-normalize-positions": "4.0.2",
-        "postcss-normalize-repeat-style": "4.0.2",
-        "postcss-normalize-string": "4.0.2",
-        "postcss-normalize-timing-functions": "4.0.2",
-        "postcss-normalize-unicode": "4.0.1",
-        "postcss-normalize-url": "4.0.1",
-        "postcss-normalize-whitespace": "4.0.2",
-        "postcss-ordered-values": "4.1.2",
-        "postcss-reduce-initial": "4.0.3",
-        "postcss-reduce-transforms": "4.0.2",
-        "postcss-svgo": "4.0.2",
-        "postcss-unique-selectors": "4.0.1"
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.1",
+        "postcss-colormin": "^4.0.3",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.2",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.11",
+        "postcss-merge-rules": "^4.0.3",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.2",
+        "postcss-minify-params": "^4.0.2",
+        "postcss-minify-selectors": "^4.0.2",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.2",
+        "postcss-normalize-positions": "^4.0.2",
+        "postcss-normalize-repeat-style": "^4.0.2",
+        "postcss-normalize-string": "^4.0.2",
+        "postcss-normalize-timing-functions": "^4.0.2",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.2",
+        "postcss-ordered-values": "^4.1.2",
+        "postcss-reduce-initial": "^4.0.3",
+        "postcss-reduce-transforms": "^4.0.2",
+        "postcss-svgo": "^4.0.2",
+        "postcss-unique-selectors": "^4.0.1"
       }
     },
     "cssnano-util-get-arguments": {
@@ -4238,7 +4257,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
       "integrity": "sha1-sm1f1fcqEd/np4RvtMZyYPlr8oI=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "cssnano-util-same-parent": {
@@ -4259,8 +4278,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
           "integrity": "sha1-P6nU7zFCy9HDAedmTB81K9gvWjk=",
           "requires": {
-            "mdn-data": "1.1.4",
-            "source-map": "0.5.7"
+            "mdn-data": "~1.1.0",
+            "source-map": "^0.5.3"
           }
         },
         "mdn-data": {
@@ -4280,7 +4299,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cssstyle/-/cssstyle-1.4.0.tgz",
       "integrity": "sha1-nTEyginTxWXGHlhrAgQaKPzNzPE=",
       "requires": {
-        "cssom": "0.3.8"
+        "cssom": "0.3.x"
       }
     },
     "csstype": {
@@ -4298,8 +4317,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/d/-/d-1.0.1.tgz",
       "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
       "requires": {
-        "es5-ext": "0.10.50",
-        "type": "1.0.3"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "damerau-levenshtein": {
@@ -4312,7 +4331,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -4320,9 +4339,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
       "requires": {
-        "abab": "2.0.0",
-        "whatwg-mimetype": "2.3.0",
-        "whatwg-url": "7.0.0"
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
       },
       "dependencies": {
         "whatwg-url": {
@@ -4330,9 +4349,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/whatwg-url/-/whatwg-url-7.0.0.tgz",
           "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
           "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
           }
         }
       }
@@ -4347,7 +4366,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/debug/-/debug-4.1.1.tgz",
       "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -4380,8 +4399,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/default-gateway/-/default-gateway-4.2.0.tgz",
       "integrity": "sha1-FnEEx1AMIRX23WmwpTa7jtcgVSs=",
       "requires": {
-        "execa": "1.0.0",
-        "ip-regex": "2.1.0"
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
       }
     },
     "define-properties": {
@@ -4389,7 +4408,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -4397,8 +4416,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -4406,7 +4425,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -4414,7 +4433,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -4422,9 +4441,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -4439,12 +4458,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "6.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "p-map": "1.2.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.3"
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "globby": {
@@ -4452,11 +4471,11 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.4",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -4483,8 +4502,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -4507,8 +4526,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
       "integrity": "sha1-JHB96r6TLUo89iEwICfCsmZWgnU=",
       "requires": {
-        "address": "1.1.0",
-        "debug": "2.6.9"
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
       },
       "dependencies": {
         "debug": {
@@ -4536,9 +4555,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.1.0"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dir-glob": {
@@ -4546,8 +4565,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha1-CyBdK2rvmCOMooZZioIE0p0KADQ=",
       "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
       }
     },
     "dns-equal": {
@@ -4560,8 +4579,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha1-EqpCaYEHW+UAuRDu3NC0fdfe2lo=",
       "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.2"
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "dns-txt": {
@@ -4569,7 +4588,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
-        "buffer-indexof": "1.1.1"
+        "buffer-indexof": "^1.0.0"
       }
     },
     "doctrine": {
@@ -4577,7 +4596,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
       "requires": {
-        "esutils": "2.0.3"
+        "esutils": "^2.0.2"
       }
     },
     "dom-converter": {
@@ -4585,7 +4604,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/dom-converter/-/dom-converter-0.2.0.tgz",
       "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
       "requires": {
-        "utila": "0.4.0"
+        "utila": "~0.4"
       }
     },
     "dom-helpers": {
@@ -4593,7 +4612,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha1-6bNpcA+Vn2Ls3lprq95LzNkWmvg=",
       "requires": {
-        "@babel/runtime": "7.5.5"
+        "@babel/runtime": "^7.1.2"
       }
     },
     "dom-serializer": {
@@ -4601,8 +4620,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/dom-serializer/-/dom-serializer-0.2.1.tgz",
       "integrity": "sha1-E2UMhQ2v/qNdi2JqTPxNOhdkP9s=",
       "requires": {
-        "domelementtype": "2.0.1",
-        "entities": "2.0.0"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
@@ -4627,7 +4646,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
       "requires": {
-        "webidl-conversions": "4.0.2"
+        "webidl-conversions": "^4.0.2"
       }
     },
     "domhandler": {
@@ -4635,7 +4654,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "requires": {
-        "domelementtype": "1.3.1"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -4643,8 +4662,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
       "requires": {
-        "dom-serializer": "0.2.1",
-        "domelementtype": "1.3.1"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -4652,7 +4671,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "dotenv": {
@@ -4670,10 +4689,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/downshift/-/downshift-3.2.12.tgz",
       "integrity": "sha1-Gdw7OOLQcMgU8l1n06Qw4b0lz3Q=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "compute-scroll-into-view": "1.0.11",
-        "prop-types": "15.7.2",
-        "react-is": "16.9.0"
+        "@babel/runtime": "^7.4.5",
+        "compute-scroll-into-view": "^1.0.9",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6"
       }
     },
     "duplexer": {
@@ -4686,10 +4705,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -4697,13 +4716,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -4711,7 +4730,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -4721,8 +4740,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -4740,13 +4759,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/elliptic/-/elliptic-6.5.0.tgz",
       "integrity": "sha1-K47UyJG33jIA4UQSpbgkjHr1Bco=",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.7",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emoji-regex": {
@@ -4769,7 +4788,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -4777,7 +4796,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -4785,9 +4804,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
       "integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
       "requires": {
-        "graceful-fs": "4.2.2",
-        "memory-fs": "0.4.1",
-        "tapable": "1.1.3"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "tapable": "^1.0.0"
       }
     },
     "entities": {
@@ -4800,7 +4819,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/errno/-/errno-0.1.7.tgz",
       "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -4808,7 +4827,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -4816,12 +4835,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
       "requires": {
-        "es-to-primitive": "1.2.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4",
-        "object-keys": "1.1.1"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
@@ -4829,9 +4848,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.2"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es5-ext": {
@@ -4839,9 +4858,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/es5-ext/-/es5-ext-0.10.50.tgz",
       "integrity": "sha1-bQ4joKvbJwGOWsT9CbQSvFUXp3g=",
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -4849,9 +4868,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1.0.1",
-        "es5-ext": "0.10.50",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-symbol": {
@@ -4859,8 +4878,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1.0.1",
-        "es5-ext": "0.10.50"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "escape-html": {
@@ -4878,11 +4897,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/escodegen/-/escodegen-1.12.0.tgz",
       "integrity": "sha1-92Pa+ECvFyuzorbdchnA4X9/9UE=",
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.3.0",
-        "esutils": "2.0.3",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -4903,43 +4922,43 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint/-/eslint-6.1.0.tgz",
       "integrity": "sha1-BkOKSieLHYT7EH0k6qo1RxmG5kY=",
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "ajv": "6.10.2",
-        "chalk": "2.4.2",
-        "cross-spawn": "6.0.5",
-        "debug": "4.1.1",
-        "doctrine": "3.0.0",
-        "eslint-scope": "5.0.0",
-        "eslint-utils": "1.4.0",
-        "eslint-visitor-keys": "1.1.0",
-        "espree": "6.0.0",
-        "esquery": "1.0.1",
-        "esutils": "2.0.3",
-        "file-entry-cache": "5.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "glob-parent": "5.0.0",
-        "globals": "11.12.0",
-        "ignore": "4.0.6",
-        "import-fresh": "3.1.0",
-        "imurmurhash": "0.1.4",
-        "inquirer": "6.5.1",
-        "is-glob": "4.0.1",
-        "js-yaml": "3.13.1",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "progress": "2.0.3",
-        "regexpp": "2.0.1",
-        "semver": "6.3.0",
-        "strip-ansi": "5.2.0",
-        "strip-json-comments": "3.0.1",
-        "table": "5.4.6",
-        "text-table": "0.2.0",
-        "v8-compile-cache": "2.1.0"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^6.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "eslint-scope": {
@@ -4947,8 +4966,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
           "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
           "requires": {
-            "esrecurse": "4.2.1",
-            "estraverse": "4.3.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         },
         "import-fresh": {
@@ -4956,8 +4975,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/import-fresh/-/import-fresh-3.1.0.tgz",
           "integrity": "sha1-bTP6Hc7235MPrgA0RvM0Fa+QURg=",
           "requires": {
-            "parent-module": "1.0.1",
-            "resolve-from": "4.0.0"
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
           }
         },
         "resolve-from": {
@@ -4972,7 +4991,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-config-react-app/-/eslint-config-react-app-5.0.1.tgz",
       "integrity": "sha1-Xz1ma6PuPLOE65Q+Jg6Gj2xyJRs=",
       "requires": {
-        "confusing-browser-globals": "1.0.8"
+        "confusing-browser-globals": "^1.0.8"
       }
     },
     "eslint-import-resolver-node": {
@@ -4980,8 +4999,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
       "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.12.0"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -5004,11 +5023,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-loader/-/eslint-loader-2.2.1.tgz",
       "integrity": "sha1-KLnBLaVAV68IReKmEScBova/gzc=",
       "requires": {
-        "loader-fs-cache": "1.0.2",
-        "loader-utils": "1.2.3",
-        "object-assign": "4.1.1",
-        "object-hash": "1.3.1",
-        "rimraf": "2.6.3"
+        "loader-fs-cache": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "object-assign": "^4.0.1",
+        "object-hash": "^1.1.4",
+        "rimraf": "^2.6.1"
       }
     },
     "eslint-module-utils": {
@@ -5016,8 +5035,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
       "integrity": "sha1-e0Z1h1v5aw2/GyGXdFblux9eAYw=",
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "2.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -5033,7 +5052,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "locate-path": {
@@ -5041,8 +5060,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "ms": {
@@ -5055,7 +5074,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -5063,7 +5082,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -5076,7 +5095,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "requires": {
-            "find-up": "2.1.0"
+            "find-up": "^2.1.0"
           }
         }
       }
@@ -5086,7 +5105,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz",
       "integrity": "sha1-4kHr05wM5Rk0Wj8HTsHr3kz4Dyw=",
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "eslint-plugin-import": {
@@ -5094,17 +5113,17 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha1-AvEYC5Cwd7M9RHoXojJs60AKzrY=",
       "requires": {
-        "array-includes": "3.0.3",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.4.1",
-        "has": "1.0.3",
-        "minimatch": "3.0.4",
-        "object.values": "1.1.0",
-        "read-pkg-up": "2.0.0",
-        "resolve": "1.12.0"
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -5120,8 +5139,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "requires": {
-            "esutils": "2.0.3",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "find-up": {
@@ -5129,7 +5148,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -5137,10 +5156,10 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
-            "graceful-fs": "4.2.2",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "locate-path": {
@@ -5148,8 +5167,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "ms": {
@@ -5162,7 +5181,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -5170,7 +5189,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -5183,7 +5202,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.2"
+            "error-ex": "^1.2.0"
           }
         },
         "path-type": {
@@ -5191,7 +5210,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "pify": {
@@ -5204,9 +5223,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.5.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -5214,8 +5233,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         }
       }
@@ -5225,15 +5244,15 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
       "integrity": "sha1-uHKgnV3lGvcKl9se6n3JMwQ3CKo=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "aria-query": "3.0.0",
-        "array-includes": "3.0.3",
-        "ast-types-flow": "0.0.7",
-        "axobject-query": "2.0.2",
-        "damerau-levenshtein": "1.0.5",
-        "emoji-regex": "7.0.3",
-        "has": "1.0.3",
-        "jsx-ast-utils": "2.2.1"
+        "@babel/runtime": "^7.4.5",
+        "aria-query": "^3.0.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.2",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^7.0.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.2.1"
       },
       "dependencies": {
         "emoji-regex": {
@@ -5248,15 +5267,15 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
       "integrity": "sha1-kRAw3X6YuknhsiCFmVcYRqZr3xM=",
       "requires": {
-        "array-includes": "3.0.3",
-        "doctrine": "2.1.0",
-        "has": "1.0.3",
-        "jsx-ast-utils": "2.2.1",
-        "object.entries": "1.1.0",
-        "object.fromentries": "2.0.0",
-        "object.values": "1.1.0",
-        "prop-types": "15.7.2",
-        "resolve": "1.12.0"
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
       },
       "dependencies": {
         "doctrine": {
@@ -5264,7 +5283,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
           "requires": {
-            "esutils": "2.0.3"
+            "esutils": "^2.0.2"
           }
         }
       }
@@ -5279,8 +5298,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
       "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.3.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -5288,7 +5307,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eslint-utils/-/eslint-utils-1.4.0.tgz",
       "integrity": "sha1-4sPI26doQl+JfPD55R/i4kFIXUw=",
       "requires": {
-        "eslint-visitor-keys": "1.1.0"
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "eslint-visitor-keys": {
@@ -5301,9 +5320,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/espree/-/espree-6.0.0.tgz",
       "integrity": "sha1-cW/B9aJF71uaf9sdew0/AjIudfY=",
       "requires": {
-        "acorn": "6.3.0",
-        "acorn-jsx": "5.0.1",
-        "eslint-visitor-keys": "1.1.0"
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
@@ -5316,7 +5335,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "requires": {
-        "estraverse": "4.3.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -5324,7 +5343,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "requires": {
-        "estraverse": "4.3.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -5357,7 +5376,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/eventsource/-/eventsource-1.0.7.tgz",
       "integrity": "sha1-j7xyyT/NNAiAkLwKTmT0tc7m2NA=",
       "requires": {
-        "original": "1.0.2"
+        "original": "^1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -5365,8 +5384,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "requires": {
-        "md5.js": "1.3.5",
-        "safe-buffer": "5.1.2"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exec-sh": {
@@ -5379,13 +5398,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/execa/-/execa-1.0.0.tgz",
       "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "4.1.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exit": {
@@ -5398,13 +5417,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -5420,7 +5439,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -5428,7 +5447,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "ms": {
@@ -5443,12 +5462,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/expect/-/expect-24.9.0.tgz",
       "integrity": "sha1-t1FltIFwdPpKFXeU9G/p8boVtso=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "ansi-styles": "3.2.1",
-        "jest-get-type": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-regex-util": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "ansi-styles": "^3.2.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.9.0"
       }
     },
     "express": {
@@ -5456,36 +5475,36 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/express/-/express-4.17.1.tgz",
       "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
         "body-parser": "1.19.0",
         "content-disposition": "0.5.3",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
-        "finalhandler": "1.1.2",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.5",
+        "proxy-addr": "~2.0.5",
         "qs": "6.7.0",
-        "range-parser": "1.2.1",
+        "range-parser": "~1.2.1",
         "safe-buffer": "5.1.2",
         "send": "0.17.1",
         "serve-static": "1.14.1",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
-        "type-is": "1.6.18",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -5523,8 +5542,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -5532,7 +5551,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -5542,9 +5561,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -5552,14 +5571,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -5567,7 +5586,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -5575,7 +5594,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -5583,7 +5602,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -5591,7 +5610,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -5599,9 +5618,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -5626,12 +5645,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fast-glob/-/fast-glob-2.2.7.tgz",
       "integrity": "sha1-aVOFfDr6R1//ku5gFdUtpwpM050=",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.1.3",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.1",
-        "merge2": "1.2.4",
-        "micromatch": "3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
       },
       "dependencies": {
         "glob-parent": {
@@ -5639,8 +5658,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -5648,7 +5667,7 @@
               "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -5670,7 +5689,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/faye-websocket/-/faye-websocket-0.11.3.tgz",
       "integrity": "sha1-XA6aiWjokSwoZjn96XeosgnyUI4=",
       "requires": {
-        "websocket-driver": "0.7.3"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fb-watchman": {
@@ -5678,7 +5697,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
-        "bser": "2.1.0"
+        "bser": "^2.0.0"
       }
     },
     "fbjs": {
@@ -5686,13 +5705,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.20"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
       },
       "dependencies": {
         "core-js": {
@@ -5705,7 +5724,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/promise/-/promise-7.3.1.tgz",
           "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
           "requires": {
-            "asap": "2.0.6"
+            "asap": "~2.0.3"
           }
         }
       }
@@ -5720,7 +5739,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/figures/-/figures-3.0.0.tgz",
       "integrity": "sha1-dWJ1yWRkYWPMb5GXx6ApXb/QTek=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -5728,7 +5747,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
       "requires": {
-        "flat-cache": "2.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "file-loader": {
@@ -5736,8 +5755,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/file-loader/-/file-loader-3.0.1.tgz",
       "integrity": "sha1-+OC6C1mZGLUa3+RdZtHnca1WD6o=",
       "requires": {
-        "loader-utils": "1.2.3",
-        "schema-utils": "1.0.0"
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^1.0.0"
       }
     },
     "filesize": {
@@ -5750,10 +5769,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5761,7 +5780,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -5772,12 +5791,12 @@
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
-        "statuses": "1.5.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -5800,9 +5819,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "2.1.0",
-        "pkg-dir": "3.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
       }
     },
     "find-up": {
@@ -5810,7 +5829,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "requires": {
-        "locate-path": "3.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "flat-cache": {
@@ -5818,7 +5837,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
       "requires": {
-        "flatted": "2.0.1",
+        "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
@@ -5838,8 +5857,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
       },
       "dependencies": {
         "readable-stream": {
@@ -5847,13 +5866,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -5861,7 +5880,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -5871,7 +5890,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha1-SJ68GY3A5/ZBZ70jsDxMGbV4THY=",
       "requires": {
-        "debug": "3.2.6"
+        "debug": "^3.2.6"
       },
       "dependencies": {
         "debug": {
@@ -5879,7 +5898,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -5894,7 +5913,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -5907,14 +5926,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.5.0.tgz",
       "integrity": "sha1-zh13GQtE2Bp2GxC2KEo3N5XkHww=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.2",
-        "chokidar": "2.1.6",
-        "micromatch": "3.1.10",
-        "minimatch": "3.0.4",
-        "semver": "5.7.1",
-        "tapable": "1.1.3",
-        "worker-rpc": "0.1.1"
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.4.1",
+        "chokidar": "^2.0.4",
+        "micromatch": "^3.1.10",
+        "minimatch": "^3.0.4",
+        "semver": "^5.6.0",
+        "tapable": "^1.0.0",
+        "worker-rpc": "^0.1.0"
       },
       "dependencies": {
         "semver": {
@@ -5929,9 +5948,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.8",
-        "mime-types": "2.1.24"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -5944,7 +5963,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -5957,8 +5976,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -5966,13 +5985,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -5980,7 +5999,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -5990,9 +6009,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "requires": {
-        "graceful-fs": "4.2.2",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -6000,10 +6019,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "requires": {
-        "graceful-fs": "4.2.2",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       },
       "dependencies": {
         "readable-stream": {
@@ -6011,13 +6030,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -6025,7 +6044,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -6066,7 +6085,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
       "requires": {
-        "pump": "3.0.0"
+        "pump": "^3.0.0"
       }
     },
     "get-value": {
@@ -6079,7 +6098,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -6087,12 +6106,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/glob/-/glob-7.1.4.tgz",
       "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -6100,7 +6119,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/glob-parent/-/glob-parent-5.0.0.tgz",
       "integrity": "sha1-HcmfDzmwBtPpLCwoQGg4Lwwg6VQ=",
       "requires": {
-        "is-glob": "4.0.1"
+        "is-glob": "^4.0.1"
       }
     },
     "glob-to-regexp": {
@@ -6113,7 +6132,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
       "requires": {
-        "global-prefix": "3.0.0"
+        "global-prefix": "^3.0.0"
       }
     },
     "global-prefix": {
@@ -6121,9 +6140,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
       "requires": {
-        "ini": "1.3.5",
-        "kind-of": "6.0.2",
-        "which": "1.3.1"
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
       },
       "dependencies": {
         "kind-of": {
@@ -6143,13 +6162,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/globby/-/globby-8.0.2.tgz",
       "integrity": "sha1-VpdhnM2VxSdduy1vqkIIfBqUHY0=",
       "requires": {
-        "array-union": "1.0.2",
+        "array-union": "^1.0.1",
         "dir-glob": "2.0.0",
-        "fast-glob": "2.2.7",
-        "glob": "7.1.4",
-        "ignore": "3.3.10",
-        "pify": "3.0.0",
-        "slash": "1.0.0"
+        "fast-glob": "^2.0.2",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
       },
       "dependencies": {
         "ignore": {
@@ -6174,7 +6193,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/graphql/-/graphql-14.4.2.tgz",
       "integrity": "sha1-VTp9VG1SRmPtpJ7W33dXe+MgOuM=",
       "requires": {
-        "iterall": "1.2.2"
+        "iterall": "^1.2.2"
       }
     },
     "graphql-tag": {
@@ -6197,8 +6216,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/gzip-size/-/gzip-size-5.1.1.tgz",
       "integrity": "sha1-y5vuaS+HwGErIyhAqHOQTkwTUnQ=",
       "requires": {
-        "duplexer": "0.1.1",
-        "pify": "4.0.1"
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
       },
       "dependencies": {
         "pify": {
@@ -6218,10 +6237,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/handlebars/-/handlebars-4.1.2.tgz",
       "integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
       "requires": {
-        "neo-async": "2.6.1",
-        "optimist": "0.6.1",
-        "source-map": "0.6.1",
-        "uglify-js": "3.4.10"
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       },
       "dependencies": {
         "source-map": {
@@ -6241,8 +6260,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "requires": {
-        "ajv": "6.10.2",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "harmony-reflect": {
@@ -6255,7 +6274,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -6263,7 +6282,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6288,9 +6307,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -6298,8 +6317,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6307,7 +6326,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6317,8 +6336,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -6326,8 +6345,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
       "requires": {
-        "inherits": "2.0.4",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "he": {
@@ -6345,9 +6364,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "1.1.7",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoist-non-react-statics": {
@@ -6355,7 +6374,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
       "integrity": "sha1-sJF48BIhhPuVrPUl2q7LTY9FlYs=",
       "requires": {
-        "react-is": "16.9.0"
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -6368,10 +6387,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
-        "inherits": "2.0.4",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.6",
-        "wbuf": "1.7.3"
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -6379,13 +6398,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -6393,7 +6412,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -6418,7 +6437,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
       "requires": {
-        "whatwg-encoding": "1.0.5"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "html-entities": {
@@ -6431,13 +6450,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/html-minifier/-/html-minifier-3.5.21.tgz",
       "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
       "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.2.1",
-        "commander": "2.17.1",
-        "he": "1.2.0",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.4.10"
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
       },
       "dependencies": {
         "commander": {
@@ -6452,11 +6471,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.5.tgz",
       "integrity": "sha1-LFMIPBFRv+wgR5sfiq8AOed7VRM=",
       "requires": {
-        "html-minifier": "3.5.21",
-        "loader-utils": "1.2.3",
-        "lodash": "4.17.15",
-        "pretty-error": "2.1.1",
-        "tapable": "1.1.3",
+        "html-minifier": "^3.5.20",
+        "loader-utils": "^1.1.0",
+        "lodash": "^4.17.11",
+        "pretty-error": "^2.1.1",
+        "tapable": "^1.1.0",
         "util.promisify": "1.0.0"
       }
     },
@@ -6465,12 +6484,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
       "requires": {
-        "domelementtype": "1.3.1",
-        "domhandler": "2.4.2",
-        "domutils": "1.7.0",
-        "entities": "1.1.2",
-        "inherits": "2.0.4",
-        "readable-stream": "3.4.0"
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "entities": {
@@ -6490,10 +6509,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.1",
-        "statuses": "1.5.0",
+        "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       },
       "dependencies": {
@@ -6514,9 +6533,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha1-etOElGWPhGBeL220Q230EPTlvpo=",
       "requires": {
-        "eventemitter3": "3.1.2",
-        "follow-redirects": "1.7.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -6524,10 +6543,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
       "integrity": "sha1-GDx9xKoUeRUDBkmMIQza+WCApDo=",
       "requires": {
-        "http-proxy": "1.17.0",
-        "is-glob": "4.0.1",
-        "lodash": "4.17.15",
-        "micromatch": "3.1.10"
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
       }
     },
     "http-signature": {
@@ -6535,9 +6554,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.16.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -6555,7 +6574,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "icss-replace-symbols": {
@@ -6568,7 +6587,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/icss-utils/-/icss-utils-4.1.1.tgz",
       "integrity": "sha1-IRcLU3ie4nRHwvR91oMIFAP5pGc=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.14"
       }
     },
     "identity-obj-proxy": {
@@ -6576,7 +6595,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
       "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
       "requires": {
-        "harmony-reflect": "1.6.1"
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {
@@ -6604,7 +6623,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/import-cwd/-/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "requires": {
-        "import-from": "2.1.0"
+        "import-from": "^2.1.0"
       }
     },
     "import-fresh": {
@@ -6612,8 +6631,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "requires": {
-        "caller-path": "2.0.0",
-        "resolve-from": "3.0.0"
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
       }
     },
     "import-from": {
@@ -6621,7 +6640,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/import-from/-/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "import-local": {
@@ -6629,8 +6648,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/import-local/-/import-local-2.0.0.tgz",
       "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "requires": {
-        "pkg-dir": "3.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -6653,8 +6672,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -6672,19 +6691,19 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/inquirer/-/inquirer-6.5.1.tgz",
       "integrity": "sha1-i/t6WsAtrG/2QaxMX/F9oRL820I=",
       "requires": {
-        "ansi-escapes": "4.2.1",
-        "chalk": "2.4.2",
-        "cli-cursor": "3.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "3.1.0",
-        "figures": "3.0.0",
-        "lodash": "4.17.15",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "2.3.0",
-        "rxjs": "6.5.2",
-        "string-width": "4.1.0",
-        "strip-ansi": "5.2.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
       }
     },
     "internal-ip": {
@@ -6692,8 +6711,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/internal-ip/-/internal-ip-4.3.0.tgz",
       "integrity": "sha1-hFRSuq2dLKO2nGNaE3rLmg2tCQc=",
       "requires": {
-        "default-gateway": "4.2.0",
-        "ipaddr.js": "1.9.0"
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
       }
     },
     "invariant": {
@@ -6701,7 +6720,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -6734,7 +6753,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-arrayish": {
@@ -6747,7 +6766,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.13.1"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -6765,7 +6784,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
       "requires": {
-        "ci-info": "2.0.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-color-stop": {
@@ -6773,12 +6792,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-color-stop/-/is-color-stop-1.1.0.tgz",
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "requires": {
-        "css-color-names": "0.0.4",
-        "hex-color-regex": "1.1.0",
-        "hsl-regex": "1.0.0",
-        "hsla-regex": "1.0.0",
-        "rgb-regex": "1.0.1",
-        "rgba-regex": "1.0.0"
+        "css-color-names": "^0.0.4",
+        "hex-color-regex": "^1.1.0",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -6786,7 +6805,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-date-object": {
@@ -6799,9 +6818,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6841,7 +6860,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-in-browser": {
@@ -6854,7 +6873,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -6872,7 +6891,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -6880,7 +6899,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-object": {
@@ -6888,7 +6907,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -6901,7 +6920,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-regexp": {
@@ -6929,7 +6948,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-svg/-/is-svg-3.0.0.tgz",
       "integrity": "sha1-kyHb0pwhLlypnE+peUxxS8r6L3U=",
       "requires": {
-        "html-comment-regex": "1.1.2"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
@@ -6937,7 +6956,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -6980,8 +6999,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "3.0.0"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -6999,13 +7018,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
       "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
       "requires": {
-        "@babel/generator": "7.5.5",
-        "@babel/parser": "7.5.5",
-        "@babel/template": "7.4.4",
-        "@babel/traverse": "7.5.5",
-        "@babel/types": "7.5.5",
-        "istanbul-lib-coverage": "2.0.5",
-        "semver": "6.3.0"
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
       }
     },
     "istanbul-lib-report": {
@@ -7013,9 +7032,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
       "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
       "requires": {
-        "istanbul-lib-coverage": "2.0.5",
-        "make-dir": "2.1.0",
-        "supports-color": "6.1.0"
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "supports-color": {
@@ -7023,7 +7042,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -7033,11 +7052,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
       "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
       "requires": {
-        "debug": "4.1.1",
-        "istanbul-lib-coverage": "2.0.5",
-        "make-dir": "2.1.0",
-        "rimraf": "2.6.3",
-        "source-map": "0.6.1"
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -7052,7 +7071,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
       "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
       "requires": {
-        "handlebars": "4.1.2"
+        "handlebars": "^4.1.2"
       }
     },
     "iterall": {
@@ -7065,8 +7084,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest/-/jest-24.8.0.tgz",
       "integrity": "sha1-1d/xmE0NEAIZbpt/Evda8bKAkIE=",
       "requires": {
-        "import-local": "2.0.0",
-        "jest-cli": "24.9.0"
+        "import-local": "^2.0.0",
+        "jest-cli": "^24.8.0"
       },
       "dependencies": {
         "jest-cli": {
@@ -7074,19 +7093,19 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-cli/-/jest-cli-24.9.0.tgz",
           "integrity": "sha1-rS3mLQdHLUGcarwwH8QyuYsQ0q8=",
           "requires": {
-            "@jest/core": "24.9.0",
-            "@jest/test-result": "24.9.0",
-            "@jest/types": "24.9.0",
-            "chalk": "2.4.2",
-            "exit": "0.1.2",
-            "import-local": "2.0.0",
-            "is-ci": "2.0.0",
-            "jest-config": "24.9.0",
-            "jest-util": "24.9.0",
-            "jest-validate": "24.9.0",
-            "prompts": "2.2.1",
-            "realpath-native": "1.1.0",
-            "yargs": "13.3.0"
+            "@jest/core": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "import-local": "^2.0.0",
+            "is-ci": "^2.0.0",
+            "jest-config": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "prompts": "^2.0.1",
+            "realpath-native": "^1.1.0",
+            "yargs": "^13.3.0"
           }
         }
       }
@@ -7096,9 +7115,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
       "integrity": "sha1-CNjBXreaf6P8mCabwUtFHugvgDk=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "execa": "1.0.0",
-        "throat": "4.1.0"
+        "@jest/types": "^24.9.0",
+        "execa": "^1.0.0",
+        "throat": "^4.0.0"
       }
     },
     "jest-config": {
@@ -7106,23 +7125,23 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-config/-/jest-config-24.9.0.tgz",
       "integrity": "sha1-+xu8YMc6Rq8DWQcZ76SCXm5N0bU=",
       "requires": {
-        "@babel/core": "7.5.5",
-        "@jest/test-sequencer": "24.9.0",
-        "@jest/types": "24.9.0",
-        "babel-jest": "24.9.0",
-        "chalk": "2.4.2",
-        "glob": "7.1.4",
-        "jest-environment-jsdom": "24.9.0",
-        "jest-environment-node": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "jest-jasmine2": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "micromatch": "3.1.10",
-        "pretty-format": "24.9.0",
-        "realpath-native": "1.1.0"
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "babel-jest": "^24.9.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^24.9.0",
+        "jest-environment-node": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "pretty-format": "^24.9.0",
+        "realpath-native": "^1.1.0"
       },
       "dependencies": {
         "jest-resolve": {
@@ -7130,11 +7149,11 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.9.0.tgz",
           "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
           "requires": {
-            "@jest/types": "24.9.0",
-            "browser-resolve": "1.11.3",
-            "chalk": "2.4.2",
-            "jest-pnp-resolver": "1.2.1",
-            "realpath-native": "1.1.0"
+            "@jest/types": "^24.9.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
           }
         }
       }
@@ -7144,10 +7163,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha1-kxt9DVd4obr3RSy4FuMl43JAVdo=",
       "requires": {
-        "chalk": "2.4.2",
-        "diff-sequences": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "pretty-format": "24.9.0"
+        "chalk": "^2.0.1",
+        "diff-sequences": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-docblock": {
@@ -7155,7 +7174,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-docblock/-/jest-docblock-24.9.0.tgz",
       "integrity": "sha1-eXAgGAK6Vg4cQJLMJcvt9a9ajOI=",
       "requires": {
-        "detect-newline": "2.1.0"
+        "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
@@ -7163,11 +7182,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-each/-/jest-each-24.9.0.tgz",
       "integrity": "sha1-6y2mAuKmEImNvF8fbfO6hrVfiwU=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "jest-get-type": "24.9.0",
-        "jest-util": "24.9.0",
-        "pretty-format": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-environment-jsdom": {
@@ -7175,12 +7194,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
       "integrity": "sha1-SwgGx/yU+V7bNpppzCd47sK3N1s=",
       "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/fake-timers": "24.9.0",
-        "@jest/types": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-util": "24.9.0",
-        "jsdom": "11.12.0"
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jsdom": "^11.5.1"
       }
     },
     "jest-environment-jsdom-fourteen": {
@@ -7188,9 +7207,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-environment-jsdom-fourteen/-/jest-environment-jsdom-fourteen-0.1.0.tgz",
       "integrity": "sha1-qtY5Op1LVltppgkQm/Rp9ivxjMw=",
       "requires": {
-        "jest-mock": "24.9.0",
-        "jest-util": "24.9.0",
-        "jsdom": "14.1.0"
+        "jest-mock": "^24.5.0",
+        "jest-util": "^24.5.0",
+        "jsdom": "^14.0.0"
       },
       "dependencies": {
         "jsdom": {
@@ -7198,32 +7217,32 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jsdom/-/jsdom-14.1.0.tgz",
           "integrity": "sha1-kWRjtglJVrCmwXgslOOAzTDhmBs=",
           "requires": {
-            "abab": "2.0.0",
-            "acorn": "6.3.0",
-            "acorn-globals": "4.3.3",
-            "array-equal": "1.0.0",
-            "cssom": "0.3.8",
-            "cssstyle": "1.4.0",
-            "data-urls": "1.1.0",
-            "domexception": "1.0.1",
-            "escodegen": "1.12.0",
-            "html-encoding-sniffer": "1.0.2",
-            "nwsapi": "2.1.4",
+            "abab": "^2.0.0",
+            "acorn": "^6.0.4",
+            "acorn-globals": "^4.3.0",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.3.4",
+            "cssstyle": "^1.1.1",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.0",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.1.3",
             "parse5": "5.1.0",
-            "pn": "1.1.0",
-            "request": "2.88.0",
-            "request-promise-native": "1.0.7",
-            "saxes": "3.1.11",
-            "symbol-tree": "3.2.4",
-            "tough-cookie": "2.5.0",
-            "w3c-hr-time": "1.0.1",
-            "w3c-xmlserializer": "1.1.2",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.5",
-            "whatwg-mimetype": "2.3.0",
-            "whatwg-url": "7.0.0",
-            "ws": "6.2.1",
-            "xml-name-validator": "3.0.0"
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.5",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.5.0",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^6.1.2",
+            "xml-name-validator": "^3.0.0"
           }
         },
         "parse5": {
@@ -7236,9 +7255,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/whatwg-url/-/whatwg-url-7.0.0.tgz",
           "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
           "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
           }
         },
         "ws": {
@@ -7246,7 +7265,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ws/-/ws-6.2.1.tgz",
           "integrity": "sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=",
           "requires": {
-            "async-limiter": "1.0.1"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -7256,11 +7275,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
       "integrity": "sha1-Mz0tJ5b5aH8q7r8HQrUZ8zwcv9M=",
       "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/fake-timers": "24.9.0",
-        "@jest/types": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-util": "24.9.0"
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0"
       }
     },
     "jest-get-type": {
@@ -7273,18 +7292,18 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
       "integrity": "sha1-s4pdZCdJNOIfpBeump++t3zqrH0=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "anymatch": "2.0.0",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.2.9",
-        "graceful-fs": "4.2.2",
-        "invariant": "2.2.4",
-        "jest-serializer": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-worker": "24.9.0",
-        "micromatch": "3.1.10",
-        "sane": "4.1.0",
-        "walker": "1.0.7"
+        "@jest/types": "^24.9.0",
+        "anymatch": "^2.0.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
+        "graceful-fs": "^4.1.15",
+        "invariant": "^2.2.4",
+        "jest-serializer": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7"
       },
       "dependencies": {
         "fsevents": {
@@ -7293,8 +7312,8 @@
           "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
           "optional": true,
           "requires": {
-            "nan": "2.14.0",
-            "node-pre-gyp": "0.12.0"
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
           },
           "dependencies": {
             "abbrev": {
@@ -7304,7 +7323,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7316,19 +7336,21 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
               }
             },
@@ -7339,15 +7361,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7359,7 +7384,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "deep-extend": {
@@ -7382,7 +7407,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "fs.realpath": {
@@ -7395,14 +7420,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.3"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               }
             },
             "glob": {
@@ -7410,12 +7435,12 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "has-unicode": {
@@ -7428,7 +7453,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "ignore-walk": {
@@ -7436,7 +7461,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               }
             },
             "inflight": {
@@ -7444,13 +7469,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7460,8 +7486,9 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
@@ -7472,20 +7499,23 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
@@ -7493,12 +7523,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7513,9 +7544,9 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "debug": "4.1.1",
-                "iconv-lite": "0.4.24",
-                "sax": "1.2.4"
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
               }
             },
             "node-pre-gyp": {
@@ -7523,16 +7554,16 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "detect-libc": "1.0.3",
-                "mkdirp": "0.5.1",
-                "needle": "2.3.0",
-                "nopt": "4.0.1",
-                "npm-packlist": "1.4.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.8",
-                "rimraf": "2.6.3",
-                "semver": "5.7.0",
-                "tar": "4.4.8"
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
               }
             },
             "nopt": {
@@ -7540,8 +7571,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "abbrev": "1.1.1",
-                "osenv": "0.1.5"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "npm-bundled": {
@@ -7554,8 +7585,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "ignore-walk": "3.0.1",
-                "npm-bundled": "1.0.6"
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
               }
             },
             "npmlog": {
@@ -7563,15 +7594,16 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "1.1.5",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               }
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7581,8 +7613,9 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-homedir": {
@@ -7600,8 +7633,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "path-is-absolute": {
@@ -7619,10 +7652,10 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -7637,13 +7670,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "rimraf": {
@@ -7651,12 +7684,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7683,28 +7717,30 @@
               "bundled": true,
               "optional": true
             },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.1.2"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "safe-buffer": "~5.1.0"
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
@@ -7717,13 +7753,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "chownr": "1.1.1",
-                "fs-minipass": "1.2.5",
-                "minipass": "2.3.5",
-                "minizlib": "1.2.1",
-                "mkdirp": "0.5.1",
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
               }
             },
             "util-deprecate": {
@@ -7736,16 +7772,18 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -7756,22 +7794,22 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
       "integrity": "sha1-H3sb0yQsF3TmKsq7NkbZavw75qA=",
       "requires": {
-        "@babel/traverse": "7.5.5",
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "co": "4.6.0",
-        "expect": "24.9.0",
-        "is-generator-fn": "2.1.0",
-        "jest-each": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "pretty-format": "24.9.0",
-        "throat": "4.1.0"
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^24.9.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0",
+        "throat": "^4.0.0"
       }
     },
     "jest-leak-detector": {
@@ -7779,8 +7817,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
       "integrity": "sha1-tmXep8dxAMXE99/LFTtlzwfc+Wo=",
       "requires": {
-        "jest-get-type": "24.9.0",
-        "pretty-format": "24.9.0"
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-matcher-utils": {
@@ -7788,10 +7826,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
       "integrity": "sha1-9bNmHV5ijf/m3WUlHf2uDofDoHM=",
       "requires": {
-        "chalk": "2.4.2",
-        "jest-diff": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "pretty-format": "24.9.0"
+        "chalk": "^2.0.1",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-message-util": {
@@ -7799,14 +7837,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-message-util/-/jest-message-util-24.9.0.tgz",
       "integrity": "sha1-Un9UoeOA9eICqNEUmw7IcvQxGeM=",
       "requires": {
-        "@babel/code-frame": "7.5.5",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/stack-utils": "1.0.1",
-        "chalk": "2.4.2",
-        "micromatch": "3.1.10",
-        "slash": "2.0.0",
-        "stack-utils": "1.0.2"
+        "@babel/code-frame": "^7.0.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^2.0.1",
+        "micromatch": "^3.1.10",
+        "slash": "^2.0.0",
+        "stack-utils": "^1.0.1"
       }
     },
     "jest-mock": {
@@ -7814,7 +7852,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-mock/-/jest-mock-24.9.0.tgz",
       "integrity": "sha1-wig1VB7jebkIZzrVEIeiGFwT8cY=",
       "requires": {
-        "@jest/types": "24.9.0"
+        "@jest/types": "^24.9.0"
       }
     },
     "jest-pnp-resolver": {
@@ -7832,11 +7870,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.8.0.tgz",
       "integrity": "sha1-hLjlQIwfahFTl5Pitf6xtuciQ58=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "browser-resolve": "1.11.3",
-        "chalk": "2.4.2",
-        "jest-pnp-resolver": "1.2.1",
-        "realpath-native": "1.1.0"
+        "@jest/types": "^24.8.0",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^1.1.0"
       }
     },
     "jest-resolve-dependencies": {
@@ -7844,9 +7882,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
       "integrity": "sha1-rQVRmJWcTPuopPBmxnOj8HhlB6s=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-snapshot": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-snapshot": "^24.9.0"
       }
     },
     "jest-runner": {
@@ -7854,25 +7892,25 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-runner/-/jest-runner-24.9.0.tgz",
       "integrity": "sha1-V0+v29VEVcKzS0vfQ2WiOFf830I=",
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "graceful-fs": "4.2.2",
-        "jest-config": "24.9.0",
-        "jest-docblock": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-jasmine2": "24.9.0",
-        "jest-leak-detector": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-worker": "24.9.0",
-        "source-map-support": "0.5.13",
-        "throat": "4.1.0"
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.4.2",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.9.0",
+        "jest-docblock": "^24.3.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-leak-detector": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.6.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
       },
       "dependencies": {
         "jest-resolve": {
@@ -7880,11 +7918,11 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.9.0.tgz",
           "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
           "requires": {
-            "@jest/types": "24.9.0",
-            "browser-resolve": "1.11.3",
-            "chalk": "2.4.2",
-            "jest-pnp-resolver": "1.2.1",
-            "realpath-native": "1.1.0"
+            "@jest/types": "^24.9.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
           }
         }
       }
@@ -7894,29 +7932,29 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-runtime/-/jest-runtime-24.9.0.tgz",
       "integrity": "sha1-nxRYOvak9zFKap2fAibhp4HI5Kw=",
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/environment": "24.9.0",
-        "@jest/source-map": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/yargs": "13.0.2",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "glob": "7.1.4",
-        "graceful-fs": "4.2.2",
-        "jest-config": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "realpath-native": "1.1.0",
-        "slash": "2.0.0",
-        "strip-bom": "3.0.0",
-        "yargs": "13.3.0"
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.9.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "strip-bom": "^3.0.0",
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "jest-resolve": {
@@ -7924,11 +7962,11 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.9.0.tgz",
           "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
           "requires": {
-            "@jest/types": "24.9.0",
-            "browser-resolve": "1.11.3",
-            "chalk": "2.4.2",
-            "jest-pnp-resolver": "1.2.1",
-            "realpath-native": "1.1.0"
+            "@jest/types": "^24.9.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
           }
         }
       }
@@ -7943,19 +7981,19 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
       "integrity": "sha1-7I6cpPLsDFyHro+SXPl0l7DpUbo=",
       "requires": {
-        "@babel/types": "7.5.5",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "expect": "24.9.0",
-        "jest-diff": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "24.9.0",
-        "semver": "6.3.0"
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "expect": "^24.9.0",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^24.9.0",
+        "semver": "^6.2.0"
       },
       "dependencies": {
         "jest-resolve": {
@@ -7963,11 +8001,11 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-24.9.0.tgz",
           "integrity": "sha1-3/BMdoevNMTdflJIktnPd+XRcyE=",
           "requires": {
-            "@jest/types": "24.9.0",
-            "browser-resolve": "1.11.3",
-            "chalk": "2.4.2",
-            "jest-pnp-resolver": "1.2.1",
-            "realpath-native": "1.1.0"
+            "@jest/types": "^24.9.0",
+            "browser-resolve": "^1.11.3",
+            "chalk": "^2.0.1",
+            "jest-pnp-resolver": "^1.2.1",
+            "realpath-native": "^1.1.0"
           }
         }
       }
@@ -7977,18 +8015,18 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-util/-/jest-util-24.9.0.tgz",
       "integrity": "sha1-c5aBTkhTbS6Fo33j5MQx18sUAWI=",
       "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/fake-timers": "24.9.0",
-        "@jest/source-map": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "callsites": "3.1.0",
-        "chalk": "2.4.2",
-        "graceful-fs": "4.2.2",
-        "is-ci": "2.0.0",
-        "mkdirp": "0.5.1",
-        "slash": "2.0.0",
-        "source-map": "0.6.1"
+        "@jest/console": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/source-map": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "callsites": "^3.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.15",
+        "is-ci": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "callsites": {
@@ -8008,12 +8046,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-validate/-/jest-validate-24.9.0.tgz",
       "integrity": "sha1-B3XFU2DRc82FTkAYB1bU/1Le+Ks=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "camelcase": "5.3.1",
-        "chalk": "2.4.2",
-        "jest-get-type": "24.9.0",
-        "leven": "3.1.0",
-        "pretty-format": "24.9.0"
+        "@jest/types": "^24.9.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^24.9.0"
       }
     },
     "jest-watch-typeahead": {
@@ -8021,12 +8059,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-watch-typeahead/-/jest-watch-typeahead-0.3.1.tgz",
       "integrity": "sha1-R3AQJLZLREqjJdgBtLOm1h7XBwE=",
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "jest-watcher": "24.9.0",
-        "slash": "2.0.0",
-        "string-length": "2.0.0",
-        "strip-ansi": "5.2.0"
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.4.1",
+        "jest-watcher": "^24.3.0",
+        "slash": "^2.0.0",
+        "string-length": "^2.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -8041,13 +8079,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-watcher/-/jest-watcher-24.9.0.tgz",
       "integrity": "sha1-S1bl0c7/AF9biOUo3Jr8jdTtKzs=",
       "requires": {
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/yargs": "13.0.2",
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "jest-util": "24.9.0",
-        "string-length": "2.0.0"
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "jest-util": "^24.9.0",
+        "string-length": "^2.0.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -8062,8 +8100,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jest-worker/-/jest-worker-24.9.0.tgz",
       "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
       "requires": {
-        "merge-stream": "2.0.0",
-        "supports-color": "6.1.0"
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "supports-color": {
@@ -8071,7 +8109,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -8091,8 +8129,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -8105,32 +8143,32 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jsdom/-/jsdom-11.12.0.tgz",
       "integrity": "sha1-GoDUDd03ih3lllbp5txaO6hle8g=",
       "requires": {
-        "abab": "2.0.0",
-        "acorn": "5.7.3",
-        "acorn-globals": "4.3.3",
-        "array-equal": "1.0.0",
-        "cssom": "0.3.8",
-        "cssstyle": "1.4.0",
-        "data-urls": "1.1.0",
-        "domexception": "1.0.1",
-        "escodegen": "1.12.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.3.0",
-        "nwsapi": "2.1.4",
+        "abab": "^2.0.0",
+        "acorn": "^5.5.3",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": "^1.0.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.9.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "nwsapi": "^2.0.7",
         "parse5": "4.0.0",
-        "pn": "1.1.0",
-        "request": "2.88.0",
-        "request-promise-native": "1.0.7",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.4",
-        "tough-cookie": "2.5.0",
-        "w3c-hr-time": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.5",
-        "whatwg-mimetype": "2.3.0",
-        "whatwg-url": "6.5.0",
-        "ws": "5.2.2",
-        "xml-name-validator": "3.0.0"
+        "pn": "^1.1.0",
+        "request": "^2.87.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.4",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^5.2.0",
+        "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -8165,7 +8203,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -8188,7 +8226,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/json5/-/json5-2.1.0.tgz",
       "integrity": "sha1-56DGLEgoXGKNIKELhcibuAfDKFA=",
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.2.0"
       }
     },
     "jsonfile": {
@@ -8196,7 +8234,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.2.2"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -8220,10 +8258,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jss/-/jss-10.0.0-alpha.23.tgz",
       "integrity": "sha1-ioZsxJUTsVWLGiwFBKS1kgecD/g=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "csstype": "2.6.6",
-        "is-in-browser": "1.1.3",
-        "tiny-warning": "1.0.3"
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^2.6.5",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-camel-case": {
@@ -8231,8 +8269,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.23.tgz",
       "integrity": "sha1-xP58b1N6z75hd4hGSmnYmx6fEMM=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "hyphenate-style-name": "1.0.3",
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
         "jss": "10.0.0-alpha.23"
       }
     },
@@ -8241,7 +8279,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.23.tgz",
       "integrity": "sha1-gmuNnn01r4YzEnms2cLTZHqvA2U=",
       "requires": {
-        "@babel/runtime": "7.5.5",
+        "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.23"
       }
     },
@@ -8250,7 +8288,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.23.tgz",
       "integrity": "sha1-uDQ8MTwx5KVTEKRGsf/j+Dtdxa8=",
       "requires": {
-        "@babel/runtime": "7.5.5",
+        "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.23"
       }
     },
@@ -8259,9 +8297,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.23.tgz",
       "integrity": "sha1-Q3NTlcq8clI5j/qe+jxyNK6hXwY=",
       "requires": {
-        "@babel/runtime": "7.5.5",
+        "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.23",
-        "tiny-warning": "1.0.3"
+        "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-props-sort": {
@@ -8269,7 +8307,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.23.tgz",
       "integrity": "sha1-iVXW83ySPhGTqaLLy6E6hdJCjow=",
       "requires": {
-        "@babel/runtime": "7.5.5",
+        "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.23"
       }
     },
@@ -8278,7 +8316,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.23.tgz",
       "integrity": "sha1-PauGaBEAV2HLrgaivCvAscmfP7Q=",
       "requires": {
-        "@babel/runtime": "7.5.5",
+        "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.23"
       }
     },
@@ -8287,8 +8325,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.23.tgz",
       "integrity": "sha1-k6gCbyYGZsZ5B0WQ/UGRhi+rtk0=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "css-vendor": "2.0.6",
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.5",
         "jss": "10.0.0-alpha.23"
       }
     },
@@ -8297,8 +8335,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
       "integrity": "sha1-TUlz6/i50oN+6RqCCMxm86J3bPs=",
       "requires": {
-        "array-includes": "3.0.3",
-        "object.assign": "4.1.0"
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
       }
     },
     "killable": {
@@ -8311,7 +8349,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "kleur": {
@@ -8324,8 +8362,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
       "integrity": "sha1-l0LfDhDjz0blwDgcLekNOnotdVU=",
       "requires": {
-        "lodash": "4.17.15",
-        "webpack-sources": "1.4.3"
+        "lodash": "^4.17.5",
+        "webpack-sources": "^1.1.0"
       }
     },
     "lazy-cache": {
@@ -8338,7 +8376,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
       "requires": {
-        "invert-kv": "2.0.0"
+        "invert-kv": "^2.0.0"
       }
     },
     "left-pad": {
@@ -8356,8 +8394,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -8365,10 +8403,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
-        "graceful-fs": "4.2.2",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "loader-fs-cache": {
@@ -8376,7 +8414,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
       "integrity": "sha1-VM7fa3J+F3n9jwEgXwX26IcG8IY=",
       "requires": {
-        "find-cache-dir": "0.1.1",
+        "find-cache-dir": "^0.1.1",
         "mkdirp": "0.5.1"
       },
       "dependencies": {
@@ -8385,9 +8423,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -8395,8 +8433,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -8404,7 +8442,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -8412,7 +8450,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         }
       }
@@ -8427,9 +8465,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
       "requires": {
-        "big.js": "5.2.2",
-        "emojis-list": "2.1.0",
-        "json5": "1.0.1"
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
       },
       "dependencies": {
         "json5": {
@@ -8437,7 +8475,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
           "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
           "requires": {
-            "minimist": "1.2.0"
+            "minimist": "^1.2.0"
           }
         }
       }
@@ -8447,8 +8485,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "requires": {
-        "p-locate": "3.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -8476,8 +8514,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.2.0"
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -8485,7 +8523,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "^3.0.0"
       }
     },
     "lodash.unescape": {
@@ -8508,7 +8546,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lower-case": {
@@ -8521,7 +8559,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "requires": {
-        "yallist": "3.0.3"
+        "yallist": "^3.0.2"
       }
     },
     "make-dir": {
@@ -8529,8 +8567,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "requires": {
-        "pify": "4.0.1",
-        "semver": "5.7.1"
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
       },
       "dependencies": {
         "pify": {
@@ -8550,7 +8588,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "mamacro": {
@@ -8563,7 +8601,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "requires": {
-        "p-defer": "1.0.0"
+        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -8576,7 +8614,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "md5.js": {
@@ -8584,9 +8622,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "mdn-data": {
@@ -8604,9 +8642,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/mem/-/mem-4.3.0.tgz",
       "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
       "requires": {
-        "map-age-cleaner": "0.1.3",
-        "mimic-fn": "2.1.0",
-        "p-is-promise": "2.1.0"
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "memoize-one": {
@@ -8619,8 +8657,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.6"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -8628,13 +8666,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -8642,7 +8680,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -8652,7 +8690,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/merge-anything/-/merge-anything-2.4.1.tgz",
       "integrity": "sha1-6bzK7B5J7Gy193ynjFdw0aNTFeY=",
       "requires": {
-        "is-what": "3.3.1"
+        "is-what": "^3.3.1"
       }
     },
     "merge-deep": {
@@ -8660,9 +8698,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/merge-deep/-/merge-deep-3.0.2.tgz",
       "integrity": "sha1-85+hAKTxvTT/KffSv0UI+7jYOtI=",
       "requires": {
-        "arr-union": "3.1.0",
-        "clone-deep": "0.2.4",
-        "kind-of": "3.2.2"
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
       }
     },
     "merge-descriptors": {
@@ -8695,19 +8733,19 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.13",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8722,8 +8760,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -8754,9 +8792,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
       "integrity": "sha1-rABZsCuWklFaY3EVsMyf7To1x7A=",
       "requires": {
-        "loader-utils": "1.2.3",
-        "schema-utils": "1.0.0",
-        "webpack-sources": "1.4.3"
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
       }
     },
     "minimalistic-assert": {
@@ -8774,7 +8812,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -8787,16 +8825,16 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexify": "3.7.1",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.1.1",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "3.0.0",
-        "pumpify": "1.5.1",
-        "stream-each": "1.2.3",
-        "through2": "2.0.5"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -8804,8 +8842,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -8813,7 +8851,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -8823,8 +8861,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -8854,12 +8892,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.3",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -8872,8 +8910,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
       "requires": {
-        "dns-packet": "1.3.1",
-        "thunky": "1.0.3"
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -8897,17 +8935,17 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -8947,7 +8985,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-fetch": {
@@ -8955,8 +8993,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -8974,29 +9012,29 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
       "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "3.0.0",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.1",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.6",
-        "stream-browserify": "2.0.2",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.3.0",
-        "timers-browserify": "2.0.11",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.11.1",
-        "vm-browserify": "1.1.0"
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "^1.0.1"
       },
       "dependencies": {
         "punycode": {
@@ -9009,13 +9047,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "string_decoder": {
@@ -9023,7 +9061,7 @@
               "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -9055,11 +9093,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/node-notifier/-/node-notifier-5.4.2.tgz",
       "integrity": "sha1-oREbjBpMPraNmIFcwEqJlFawPxo=",
       "requires": {
-        "growly": "1.3.0",
-        "is-wsl": "2.1.0",
-        "semver": "6.3.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.1"
+        "growly": "^1.3.0",
+        "is-wsl": "^2.1.0",
+        "semver": "^6.3.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.1"
       },
       "dependencies": {
         "is-wsl": {
@@ -9074,7 +9112,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/node-releases/-/node-releases-1.1.27.tgz",
       "integrity": "sha1-sZ7IrdKv6agmqZ3OzMUWEEwe2vQ=",
       "requires": {
-        "semver": "5.7.1"
+        "semver": "^5.3.0"
       },
       "dependencies": {
         "semver": {
@@ -9089,10 +9127,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "requires": {
-        "hosted-git-info": "2.8.4",
-        "resolve": "1.12.0",
-        "semver": "5.7.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
         "semver": {
@@ -9107,7 +9145,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -9130,7 +9168,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "nth-check": {
@@ -9138,7 +9176,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -9171,9 +9209,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -9181,7 +9219,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -9206,7 +9244,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.assign": {
@@ -9214,10 +9252,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.1.1"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.entries": {
@@ -9225,10 +9263,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "object.fromentries": {
@@ -9236,10 +9274,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/object.fromentries/-/object.fromentries-2.0.0.tgz",
       "integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -9247,8 +9285,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.pick": {
@@ -9256,7 +9294,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "object.values": {
@@ -9264,10 +9302,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "obuf": {
@@ -9293,7 +9331,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -9301,7 +9339,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
       "requires": {
-        "mimic-fn": "2.1.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "open": {
@@ -9309,7 +9347,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/open/-/open-6.4.0.tgz",
       "integrity": "sha1-XBPpbQ3IlGhhZPGJZez+iJ7PyKk=",
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "opn": {
@@ -9317,7 +9355,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/opn/-/opn-5.5.0.tgz",
       "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimism": {
@@ -9325,7 +9363,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/optimism/-/optimism-0.10.2.tgz",
       "integrity": "sha1-Ymtv0osJI96Y7LNqP9LT1OVjLdk=",
       "requires": {
-        "@wry/context": "0.4.4"
+        "@wry/context": "^0.4.0"
       }
     },
     "optimist": {
@@ -9333,8 +9371,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -9354,8 +9392,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
       "integrity": "sha1-4vHU2UrYwK+JZ+vXzxONyx7xRXI=",
       "requires": {
-        "cssnano": "4.1.10",
-        "last-call-webpack-plugin": "3.0.0"
+        "cssnano": "^4.1.10",
+        "last-call-webpack-plugin": "^3.0.0"
       }
     },
     "optionator": {
@@ -9363,12 +9401,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "original": {
@@ -9376,7 +9414,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/original/-/original-1.0.2.tgz",
       "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
       "requires": {
-        "url-parse": "1.4.7"
+        "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {
@@ -9389,9 +9427,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
       "requires": {
-        "execa": "1.0.0",
-        "lcid": "2.0.0",
-        "mem": "4.3.0"
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
       }
     },
     "os-tmpdir": {
@@ -9409,7 +9447,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "requires": {
-        "p-reduce": "1.0.0"
+        "p-reduce": "^1.0.0"
       }
     },
     "p-finally": {
@@ -9427,7 +9465,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-limit/-/p-limit-2.2.0.tgz",
       "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
       "requires": {
-        "p-try": "2.2.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -9435,7 +9473,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "requires": {
-        "p-limit": "2.2.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-map": {
@@ -9463,9 +9501,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/parallel-transform/-/parallel-transform-1.1.0.tgz",
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       },
       "dependencies": {
         "readable-stream": {
@@ -9473,13 +9511,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -9487,7 +9525,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -9497,7 +9535,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "parent-module": {
@@ -9505,7 +9543,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "requires": {
-        "callsites": "3.1.0"
+        "callsites": "^3.0.0"
       },
       "dependencies": {
         "callsites": {
@@ -9520,12 +9558,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/parse-asn1/-/parse-asn1-5.1.4.tgz",
       "integrity": "sha1-N/Zij4I/vesic7TVQENKIvPvH8w=",
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.17",
-        "safe-buffer": "5.1.2"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
       }
     },
     "parse-json": {
@@ -9533,8 +9571,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
-        "error-ex": "1.3.2",
-        "json-parse-better-errors": "1.0.2"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse5": {
@@ -9597,7 +9635,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "pbkdf2": {
@@ -9605,11 +9643,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pbkdf2/-/pbkdf2-3.0.17.tgz",
       "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -9632,7 +9670,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pirates": {
@@ -9640,7 +9678,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pirates/-/pirates-4.0.1.tgz",
       "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
       "requires": {
-        "node-modules-regexp": "1.0.0"
+        "node-modules-regexp": "^1.0.0"
       }
     },
     "pkg-dir": {
@@ -9648,7 +9686,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
       "requires": {
-        "find-up": "3.0.0"
+        "find-up": "^3.0.0"
       }
     },
     "pkg-up": {
@@ -9656,7 +9694,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pkg-up/-/pkg-up-2.0.0.tgz",
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -9664,7 +9702,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "locate-path": {
@@ -9672,8 +9710,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -9681,7 +9719,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -9689,7 +9727,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -9709,7 +9747,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pnp-webpack-plugin/-/pnp-webpack-plugin-1.5.0.tgz",
       "integrity": "sha1-YqHNMGj0bVZLszxW6yUOTVhmdus=",
       "requires": {
-        "ts-pnp": "1.1.2"
+        "ts-pnp": "^1.1.2"
       }
     },
     "popper.js": {
@@ -9722,9 +9760,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/portfinder/-/portfinder-1.0.22.tgz",
       "integrity": "sha1-q9EKSItWlumO4lxgcx+K4Ldvjd0=",
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       },
       "dependencies": {
         "debug": {
@@ -9752,9 +9790,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss/-/postcss-7.0.17.tgz",
       "integrity": "sha1-TaG9/1Mi1KCsqrTYfz54JDa60x8=",
       "requires": {
-        "chalk": "2.4.2",
-        "source-map": "0.6.1",
-        "supports-color": "6.1.0"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -9767,7 +9805,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -9777,8 +9815,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
       "integrity": "sha1-sqchoNJ5wvkQOjYzHIiYFSZCjMc=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "5.0.0"
+        "postcss": "^7.0.2",
+        "postcss-selector-parser": "^5.0.0"
       },
       "dependencies": {
         "cssesc": {
@@ -9791,9 +9829,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
           "requires": {
-            "cssesc": "2.0.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -9803,7 +9841,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-browser-comments/-/postcss-browser-comments-2.0.0.tgz",
       "integrity": "sha1-3EjWqN2/8YioCgALc5NDbLGK7Yg=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-calc": {
@@ -9811,10 +9849,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-calc/-/postcss-calc-7.0.1.tgz",
       "integrity": "sha1-Ntd7qwI7Dsu5eJ2E3LI8SUEUVDY=",
       "requires": {
-        "css-unit-converter": "1.1.1",
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "5.0.0",
-        "postcss-value-parser": "3.3.1"
+        "css-unit-converter": "^1.1.1",
+        "postcss": "^7.0.5",
+        "postcss-selector-parser": "^5.0.0-rc.4",
+        "postcss-value-parser": "^3.3.1"
       },
       "dependencies": {
         "cssesc": {
@@ -9827,9 +9865,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
           "requires": {
-            "cssesc": "2.0.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -9839,8 +9877,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
       "integrity": "sha1-Xv03qI+6vrAKKWbR5T2Yztk/dOA=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-color-gray": {
@@ -9848,9 +9886,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
       "integrity": "sha1-Uyox65CfjaiYzv/ilv3B+GS+hUc=",
       "requires": {
-        "@csstools/convert-colors": "1.4.0",
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "@csstools/convert-colors": "^1.4.0",
+        "postcss": "^7.0.5",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-color-hex-alpha": {
@@ -9858,8 +9896,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
       "integrity": "sha1-qNnKTDnUl8lmHjdLnFGJnvD4c4g=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "postcss": "^7.0.14",
+        "postcss-values-parser": "^2.0.1"
       }
     },
     "postcss-color-mod-function": {
@@ -9867,9 +9905,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
       "integrity": "sha1-gWuhRawRzDy2uqkFp1pJ+QPk0x0=",
       "requires": {
-        "@csstools/convert-colors": "1.4.0",
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "@csstools/convert-colors": "^1.4.0",
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-color-rebeccapurple": {
@@ -9877,8 +9915,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
       "integrity": "sha1-x6ib6HK7dORbHjAiv+V0iCPm3nc=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-colormin": {
@@ -9886,11 +9924,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
       "integrity": "sha1-rgYLzpPteUrHEmTwgTLVUJVr04E=",
       "requires": {
-        "browserslist": "4.6.6",
-        "color": "3.1.2",
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-convert-values": {
@@ -9898,8 +9936,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
       "integrity": "sha1-yjgT7U2g+BL51DcDWE5Enr4Ymn8=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-custom-media": {
@@ -9907,7 +9945,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
       "integrity": "sha1-//0T/+/61zYhvl84cHaiiwApTgw=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.14"
       }
     },
     "postcss-custom-properties": {
@@ -9915,8 +9953,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
       "integrity": "sha1-LWF3LW6S8i9eDVJgLfj65G+jDZc=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "postcss": "^7.0.17",
+        "postcss-values-parser": "^2.0.1"
       }
     },
     "postcss-custom-selectors": {
@@ -9924,8 +9962,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
       "integrity": "sha1-ZIWMbrLs/y+0HQsoyd17PbTef7o=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "5.0.0"
+        "postcss": "^7.0.2",
+        "postcss-selector-parser": "^5.0.0-rc.3"
       },
       "dependencies": {
         "cssesc": {
@@ -9938,9 +9976,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
           "requires": {
-            "cssesc": "2.0.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -9950,8 +9988,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
       "integrity": "sha1-bjpBd9Dts6vMhf22+7HCbauuq6I=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "5.0.0"
+        "postcss": "^7.0.2",
+        "postcss-selector-parser": "^5.0.0-rc.3"
       },
       "dependencies": {
         "cssesc": {
@@ -9964,9 +10002,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
           "requires": {
-            "cssesc": "2.0.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -9976,7 +10014,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
       "integrity": "sha1-H7q9LCRr/2qq15l7KwkY9NevQDM=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-duplicates": {
@@ -9984,7 +10022,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
       "integrity": "sha1-P+EzzTyCKC5VD8myORdqkge3hOs=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-empty": {
@@ -9992,7 +10030,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
       "integrity": "sha1-yMlR6fc+2UKAGUWERKAq2Qu592U=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-discard-overridden": {
@@ -10000,7 +10038,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
       "integrity": "sha1-ZSrvipZybwKfXj4AFG7npOdV/1c=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-double-position-gradients": {
@@ -10008,8 +10046,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
       "integrity": "sha1-/JJ9Uv3ciWyzooEuvF3xR+EQUi4=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "postcss": "^7.0.5",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-env-function": {
@@ -10017,8 +10055,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
       "integrity": "sha1-Dz49PFfwlKksK69LYkHwsNpTZdc=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-flexbugs-fixes": {
@@ -10026,7 +10064,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
       "integrity": "sha1-4JSp3xeD4iALexn4ddytOzr/iyA=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-focus-visible": {
@@ -10034,7 +10072,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
       "integrity": "sha1-R30QcROt5gJLFBKDF63ivR4XBG4=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-focus-within": {
@@ -10042,7 +10080,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
       "integrity": "sha1-djuHiFls7puHTJmSAc3egGWe9oA=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-font-variant": {
@@ -10050,7 +10088,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
       "integrity": "sha1-cd08bBCg2EbF7aB4A0OWF7u6usw=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-gap-properties": {
@@ -10058,7 +10096,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
       "integrity": "sha1-QxwZKrPtlqPD0J8v9hWWD5AsFxU=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-image-set-function": {
@@ -10066,8 +10104,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
       "integrity": "sha1-KJIKLymUW+1MMZjX32SW1BDT8og=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-initial": {
@@ -10075,8 +10113,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-initial/-/postcss-initial-3.0.1.tgz",
       "integrity": "sha1-mdMZZpoT1sBu+OcNhS9oyxs5m2E=",
       "requires": {
-        "lodash.template": "4.5.0",
-        "postcss": "7.0.17"
+        "lodash.template": "^4.5.0",
+        "postcss": "^7.0.2"
       }
     },
     "postcss-lab-function": {
@@ -10084,9 +10122,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
       "integrity": "sha1-u1GmhWzRIomrSuINseOCHvE9fS4=",
       "requires": {
-        "@csstools/convert-colors": "1.4.0",
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "@csstools/convert-colors": "^1.4.0",
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-load-config": {
@@ -10094,8 +10132,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
       "integrity": "sha1-yE1pK3u3tB3c7ZTuYuirMbQXsAM=",
       "requires": {
-        "cosmiconfig": "5.2.1",
-        "import-cwd": "2.1.0"
+        "cosmiconfig": "^5.0.0",
+        "import-cwd": "^2.0.0"
       }
     },
     "postcss-loader": {
@@ -10103,10 +10141,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-loader/-/postcss-loader-3.0.0.tgz",
       "integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
       "requires": {
-        "loader-utils": "1.2.3",
-        "postcss": "7.0.17",
-        "postcss-load-config": "2.1.0",
-        "schema-utils": "1.0.0"
+        "loader-utils": "^1.1.0",
+        "postcss": "^7.0.0",
+        "postcss-load-config": "^2.0.0",
+        "schema-utils": "^1.0.0"
       }
     },
     "postcss-logical": {
@@ -10114,7 +10152,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-logical/-/postcss-logical-3.0.0.tgz",
       "integrity": "sha1-JJXQ+LgunyYnJfdflAGzTntF1bU=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-media-minmax": {
@@ -10122,7 +10160,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
       "integrity": "sha1-t1u2y8IXyKxJQz4S8iBIgUpPXtU=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-merge-longhand": {
@@ -10131,9 +10169,9 @@
       "integrity": "sha1-YvSaE+Sg7gTnuY9CuxYGLKJUniQ=",
       "requires": {
         "css-color-names": "0.0.4",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1",
-        "stylehacks": "4.0.3"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
       }
     },
     "postcss-merge-rules": {
@@ -10141,12 +10179,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
       "integrity": "sha1-NivqT/Wh+Y5AdacTxsslrv75plA=",
       "requires": {
-        "browserslist": "4.6.6",
-        "caniuse-api": "3.0.0",
-        "cssnano-util-same-parent": "4.0.1",
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "3.1.1",
-        "vendors": "1.0.3"
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -10154,9 +10192,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -10166,8 +10204,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
       "integrity": "sha1-zUw0TM5HQ0P6xdgiBqssvLiv1aY=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-minify-gradients": {
@@ -10175,10 +10213,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
       "integrity": "sha1-k7KcL/UJnFNe7NpWxKpuZlpmNHE=",
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "is-color-stop": "1.1.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-minify-params": {
@@ -10186,12 +10224,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
       "integrity": "sha1-a5zvAwwR41Jh+V9hjJADbWgNuHQ=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "browserslist": "4.6.6",
-        "cssnano-util-get-arguments": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
       }
     },
     "postcss-minify-selectors": {
@@ -10199,10 +10237,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
       "integrity": "sha1-4uXrQL/uUA0M2SQ1APX46kJi+9g=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "3.1.1"
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -10210,9 +10248,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -10222,7 +10260,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
       "integrity": "sha1-gYcZoa4doyX5gyRGsBE27rSTzX4=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.5"
       }
     },
     "postcss-modules-local-by-default": {
@@ -10230,9 +10268,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
       "integrity": "sha1-3ZlT9t1Ha1/R7y2IMMiSl2C1bmM=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "6.0.2",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0",
+        "postcss-value-parser": "^3.3.1"
       }
     },
     "postcss-modules-scope": {
@@ -10240,8 +10278,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
       "integrity": "sha1-rT9b94VhFPb8q5AbBQLiorw51Os=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "6.0.2"
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
       }
     },
     "postcss-modules-values": {
@@ -10249,8 +10287,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
       "integrity": "sha1-R5tG3Axco9x/pScIUYNrnscVL2Q=",
       "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "7.0.17"
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^7.0.6"
       }
     },
     "postcss-nesting": {
@@ -10258,7 +10296,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-nesting/-/postcss-nesting-7.0.1.tgz",
       "integrity": "sha1-tQrXt/AXPlteOIDDUBNEcD4EwFI=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-normalize": {
@@ -10266,10 +10304,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize/-/postcss-normalize-7.0.1.tgz",
       "integrity": "sha1-61FWjZYriqYagxg4PIu35UMyKC4=",
       "requires": {
-        "@csstools/normalize.css": "9.0.1",
-        "browserslist": "4.6.6",
-        "postcss": "7.0.17",
-        "postcss-browser-comments": "2.0.0"
+        "@csstools/normalize.css": "^9.0.1",
+        "browserslist": "^4.1.1",
+        "postcss": "^7.0.2",
+        "postcss-browser-comments": "^2.0.0"
       }
     },
     "postcss-normalize-charset": {
@@ -10277,7 +10315,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
       "integrity": "sha1-izWt067oOhNrBHHg1ZvlilAoXdQ=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-normalize-display-values": {
@@ -10285,9 +10323,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
       "integrity": "sha1-Db4EpM6QY9RmftK+R2u4MMglk1o=",
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-positions": {
@@ -10295,10 +10333,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
       "integrity": "sha1-BfdX+E8mBDc3g2ipH4ky1LECkX8=",
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-repeat-style": {
@@ -10306,10 +10344,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
       "integrity": "sha1-xOu8KJ85kaAo1EdRy90RkYsXkQw=",
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-string": {
@@ -10317,9 +10355,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
       "integrity": "sha1-zUTECrB6DHo23F6Zqs4eyk7CaQw=",
       "requires": {
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-timing-functions": {
@@ -10327,9 +10365,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
       "integrity": "sha1-jgCcoqOUnNr4rSPmtquZy159KNk=",
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-unicode": {
@@ -10337,9 +10375,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
       "integrity": "sha1-hBvUj9zzAZrUuqdJOj02O1KuHPs=",
       "requires": {
-        "browserslist": "4.6.6",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-url": {
@@ -10347,10 +10385,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
       "integrity": "sha1-EOQ3+GvHx+WPe5ZS7YeNqqlfquE=",
       "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "3.3.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-normalize-whitespace": {
@@ -10358,8 +10396,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
       "integrity": "sha1-vx1AcP5Pzqh9E0joJdjMDF+qfYI=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-ordered-values": {
@@ -10367,9 +10405,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
       "integrity": "sha1-DPdcgg7H1cTSgBiVWeC1ceusDu4=",
       "requires": {
-        "cssnano-util-get-arguments": "4.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-overflow-shorthand": {
@@ -10377,7 +10415,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
       "integrity": "sha1-MezzUOnG9t3CUKePDD4RHzLdTDA=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-page-break": {
@@ -10385,7 +10423,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
       "integrity": "sha1-rdUtDgpSjKvmr+6LRuKrsnffRr8=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-place": {
@@ -10393,8 +10431,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-place/-/postcss-place-4.0.1.tgz",
       "integrity": "sha1-6fOdM9LcWE5G7h20Wtt3yp0dzGI=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-values-parser": "2.0.1"
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
       }
     },
     "postcss-preset-env": {
@@ -10402,43 +10440,43 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz",
       "integrity": "sha1-w03az4+QI4OzWtHgMPF49M3xGKU=",
       "requires": {
-        "autoprefixer": "9.6.1",
-        "browserslist": "4.6.6",
-        "caniuse-lite": "1.0.30000989",
-        "css-blank-pseudo": "0.1.4",
-        "css-has-pseudo": "0.10.0",
-        "css-prefers-color-scheme": "3.1.1",
-        "cssdb": "4.4.0",
-        "postcss": "7.0.17",
-        "postcss-attribute-case-insensitive": "4.0.1",
-        "postcss-color-functional-notation": "2.0.1",
-        "postcss-color-gray": "5.0.0",
-        "postcss-color-hex-alpha": "5.0.3",
-        "postcss-color-mod-function": "3.0.3",
-        "postcss-color-rebeccapurple": "4.0.1",
-        "postcss-custom-media": "7.0.8",
-        "postcss-custom-properties": "8.0.11",
-        "postcss-custom-selectors": "5.1.2",
-        "postcss-dir-pseudo-class": "5.0.0",
-        "postcss-double-position-gradients": "1.0.0",
-        "postcss-env-function": "2.0.2",
-        "postcss-focus-visible": "4.0.0",
-        "postcss-focus-within": "3.0.0",
-        "postcss-font-variant": "4.0.0",
-        "postcss-gap-properties": "2.0.0",
-        "postcss-image-set-function": "3.0.1",
-        "postcss-initial": "3.0.1",
-        "postcss-lab-function": "2.0.1",
-        "postcss-logical": "3.0.0",
-        "postcss-media-minmax": "4.0.0",
-        "postcss-nesting": "7.0.1",
-        "postcss-overflow-shorthand": "2.0.0",
-        "postcss-page-break": "2.0.0",
-        "postcss-place": "4.0.1",
-        "postcss-pseudo-class-any-link": "6.0.0",
-        "postcss-replace-overflow-wrap": "3.0.0",
-        "postcss-selector-matches": "4.0.0",
-        "postcss-selector-not": "4.0.0"
+        "autoprefixer": "^9.6.1",
+        "browserslist": "^4.6.4",
+        "caniuse-lite": "^1.0.30000981",
+        "css-blank-pseudo": "^0.1.4",
+        "css-has-pseudo": "^0.10.0",
+        "css-prefers-color-scheme": "^3.1.1",
+        "cssdb": "^4.4.0",
+        "postcss": "^7.0.17",
+        "postcss-attribute-case-insensitive": "^4.0.1",
+        "postcss-color-functional-notation": "^2.0.1",
+        "postcss-color-gray": "^5.0.0",
+        "postcss-color-hex-alpha": "^5.0.3",
+        "postcss-color-mod-function": "^3.0.3",
+        "postcss-color-rebeccapurple": "^4.0.1",
+        "postcss-custom-media": "^7.0.8",
+        "postcss-custom-properties": "^8.0.11",
+        "postcss-custom-selectors": "^5.1.2",
+        "postcss-dir-pseudo-class": "^5.0.0",
+        "postcss-double-position-gradients": "^1.0.0",
+        "postcss-env-function": "^2.0.2",
+        "postcss-focus-visible": "^4.0.0",
+        "postcss-focus-within": "^3.0.0",
+        "postcss-font-variant": "^4.0.0",
+        "postcss-gap-properties": "^2.0.0",
+        "postcss-image-set-function": "^3.0.1",
+        "postcss-initial": "^3.0.0",
+        "postcss-lab-function": "^2.0.1",
+        "postcss-logical": "^3.0.0",
+        "postcss-media-minmax": "^4.0.0",
+        "postcss-nesting": "^7.0.0",
+        "postcss-overflow-shorthand": "^2.0.0",
+        "postcss-page-break": "^2.0.0",
+        "postcss-place": "^4.0.1",
+        "postcss-pseudo-class-any-link": "^6.0.0",
+        "postcss-replace-overflow-wrap": "^3.0.0",
+        "postcss-selector-matches": "^4.0.0",
+        "postcss-selector-not": "^4.0.0"
       }
     },
     "postcss-pseudo-class-any-link": {
@@ -10446,8 +10484,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
       "integrity": "sha1-LtPu05OzcCh53sSocDKyENrrBNE=",
       "requires": {
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "5.0.0"
+        "postcss": "^7.0.2",
+        "postcss-selector-parser": "^5.0.0-rc.3"
       },
       "dependencies": {
         "cssesc": {
@@ -10460,9 +10498,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
           "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
           "requires": {
-            "cssesc": "2.0.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -10472,10 +10510,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
       "integrity": "sha1-f9QuvqXpyBRgljniwuhK4nC6SN8=",
       "requires": {
-        "browserslist": "4.6.6",
-        "caniuse-api": "3.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.17"
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
       }
     },
     "postcss-reduce-transforms": {
@@ -10483,10 +10521,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
       "integrity": "sha1-F++kBerMbge+NBSlyi0QdGgdTik=",
       "requires": {
-        "cssnano-util-get-match": "4.0.0",
-        "has": "1.0.3",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1"
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
       }
     },
     "postcss-replace-overflow-wrap": {
@@ -10494,7 +10532,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
       "integrity": "sha1-YbNg/9rtyoTHyRjSsPDQ6lWasBw=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.2"
       }
     },
     "postcss-safe-parser": {
@@ -10502,7 +10540,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
       "integrity": "sha1-h1bZ5MNv3OLHKwkbvIyhdqsfzeo=",
       "requires": {
-        "postcss": "7.0.17"
+        "postcss": "^7.0.0"
       }
     },
     "postcss-selector-matches": {
@@ -10510,8 +10548,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
       "integrity": "sha1-ccgkj5F7osyTA3yWN+4JxkQ2/P8=",
       "requires": {
-        "balanced-match": "1.0.0",
-        "postcss": "7.0.17"
+        "balanced-match": "^1.0.0",
+        "postcss": "^7.0.2"
       }
     },
     "postcss-selector-not": {
@@ -10519,8 +10557,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
       "integrity": "sha1-xo/3upZSdJnoMnJKJnTWVgO2RcA=",
       "requires": {
-        "balanced-match": "1.0.0",
-        "postcss": "7.0.17"
+        "balanced-match": "^1.0.0",
+        "postcss": "^7.0.2"
       }
     },
     "postcss-selector-parser": {
@@ -10528,9 +10566,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
       "integrity": "sha1-k0z3mdAWyDQRhZ4J3Oyt4BKG7Fw=",
       "requires": {
-        "cssesc": "3.0.0",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-svgo": {
@@ -10538,10 +10576,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
       "integrity": "sha1-F7mXvHEbMzurFDqu07jT1uPTglg=",
       "requires": {
-        "is-svg": "3.0.0",
-        "postcss": "7.0.17",
-        "postcss-value-parser": "3.3.1",
-        "svgo": "1.3.0"
+        "is-svg": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
       }
     },
     "postcss-unique-selectors": {
@@ -10549,9 +10587,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
       "integrity": "sha1-lEaRHzKJv9ZMbWgPBzwDsfnuS6w=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "7.0.17",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -10564,9 +10602,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
       "integrity": "sha1-2otHLZAdoeIFtHvcmGN7np5VDl8=",
       "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "prelude-ls": {
@@ -10584,8 +10622,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
-        "renderkid": "2.0.3",
-        "utila": "0.4.0"
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
       }
     },
     "pretty-format": {
@@ -10593,10 +10631,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pretty-format/-/pretty-format-24.9.0.tgz",
       "integrity": "sha1-EvrDGzcBmk7qPBGqmpWet2KKp8k=",
       "requires": {
-        "@jest/types": "24.9.0",
-        "ansi-regex": "4.1.0",
-        "ansi-styles": "3.2.1",
-        "react-is": "16.9.0"
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
       }
     },
     "private": {
@@ -10624,7 +10662,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/promise/-/promise-8.0.3.tgz",
       "integrity": "sha1-9ZLgmcbN3AANU47nKDuxkEUrC/Y=",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.6"
       }
     },
     "promise-inflight": {
@@ -10637,8 +10675,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/prompts/-/prompts-2.2.1.tgz",
       "integrity": "sha1-+QHdKi3+4IA1nA4gBZskGI11rTU=",
       "requires": {
-        "kleur": "3.0.3",
-        "sisteransi": "1.0.3"
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.3"
       }
     },
     "prop-types": {
@@ -10646,9 +10684,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "react-is": "16.9.0"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "proxy-addr": {
@@ -10656,7 +10694,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/proxy-addr/-/proxy-addr-2.0.5.tgz",
       "integrity": "sha1-NMvWSi2B9LH9IedvnwbIpFKZ7jQ=",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
       }
     },
@@ -10675,12 +10713,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.4",
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "pump": {
@@ -10688,8 +10726,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -10697,9 +10735,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "requires": {
-        "duplexify": "3.7.1",
-        "inherits": "2.0.4",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       },
       "dependencies": {
         "pump": {
@@ -10707,8 +10745,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/pump/-/pump-2.0.1.tgz",
           "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -10748,7 +10786,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/raf/-/raf-3.4.1.tgz",
       "integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
       "requires": {
-        "performance-now": "2.1.0"
+        "performance-now": "^2.1.0"
       }
     },
     "randombytes": {
@@ -10756,7 +10794,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -10764,8 +10802,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "requires": {
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -10796,9 +10834,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/react/-/react-16.9.0.tgz",
       "integrity": "sha1-QLovmvE7waONddvy9DWaUYXE96o=",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.7.2"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
       }
     },
     "react-app-polyfill": {
@@ -10836,9 +10874,9 @@
         "inquirer": "6.5.0",
         "is-root": "2.1.0",
         "loader-utils": "1.2.3",
-        "open": "6.4.0",
+        "open": "^6.3.0",
         "pkg-up": "2.0.0",
-        "react-error-overlay": "6.0.1",
+        "react-error-overlay": "^6.0.1",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.6.1",
         "sockjs-client": "1.3.0",
@@ -10861,7 +10899,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "figures": {
@@ -10869,7 +10907,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "inquirer": {
@@ -10877,19 +10915,19 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/inquirer/-/inquirer-6.5.0.tgz",
           "integrity": "sha1-IwMxfvyaTqfsLi32+GVptzSsz0I=",
           "requires": {
-            "ansi-escapes": "3.2.0",
-            "chalk": "2.4.2",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "3.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.15",
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "6.5.2",
-            "string-width": "2.1.1",
-            "strip-ansi": "5.2.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
@@ -10912,7 +10950,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -10920,8 +10958,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "string-width": {
@@ -10929,8 +10967,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -10938,7 +10976,7 @@
               "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -10950,10 +10988,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/react-dom/-/react-dom-16.9.0.tgz",
       "integrity": "sha1-XmVSel4m8irjcBExvMyu6fsNOWI=",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.7.2",
-        "scheduler": "0.15.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.15.0"
       }
     },
     "react-error-overlay": {
@@ -10981,29 +11019,29 @@
         "@typescript-eslint/eslint-plugin": "1.13.0",
         "@typescript-eslint/parser": "1.13.0",
         "babel-eslint": "10.0.2",
-        "babel-jest": "24.9.0",
+        "babel-jest": "^24.8.0",
         "babel-loader": "8.0.6",
-        "babel-plugin-named-asset-import": "0.3.3",
-        "babel-preset-react-app": "9.0.1",
-        "camelcase": "5.3.1",
+        "babel-plugin-named-asset-import": "^0.3.3",
+        "babel-preset-react-app": "^9.0.1",
+        "camelcase": "^5.2.0",
         "case-sensitive-paths-webpack-plugin": "2.2.0",
         "css-loader": "2.1.1",
         "dotenv": "6.2.0",
         "dotenv-expand": "4.2.0",
-        "eslint": "6.1.0",
-        "eslint-config-react-app": "5.0.1",
+        "eslint": "^6.1.0",
+        "eslint-config-react-app": "^5.0.1",
         "eslint-loader": "2.2.1",
         "eslint-plugin-flowtype": "3.13.0",
         "eslint-plugin-import": "2.18.2",
         "eslint-plugin-jsx-a11y": "6.2.3",
         "eslint-plugin-react": "7.14.3",
-        "eslint-plugin-react-hooks": "1.7.0",
+        "eslint-plugin-react-hooks": "^1.6.1",
         "file-loader": "3.0.1",
         "fs-extra": "7.0.1",
         "fsevents": "2.0.7",
         "html-webpack-plugin": "4.0.0-beta.5",
         "identity-obj-proxy": "3.0.0",
-        "is-wsl": "1.1.0",
+        "is-wsl": "^1.1.0",
         "jest": "24.8.0",
         "jest-environment-jsdom-fourteen": "0.1.0",
         "jest-resolve": "24.8.0",
@@ -11016,8 +11054,8 @@
         "postcss-normalize": "7.0.1",
         "postcss-preset-env": "6.7.0",
         "postcss-safe-parser": "4.0.1",
-        "react-app-polyfill": "1.0.2",
-        "react-dev-utils": "9.0.3",
+        "react-app-polyfill": "^1.0.2",
+        "react-dev-utils": "^9.0.3",
         "resolve": "1.12.0",
         "resolve-url-loader": "3.1.0",
         "sass-loader": "7.2.0",
@@ -11037,10 +11075,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/react-transition-group/-/react-transition-group-4.2.2.tgz",
       "integrity": "sha1-i1JSQQGAwn/X7r9QsYUla0F5mxY=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "dom-helpers": "3.4.0",
-        "loose-envify": "1.4.0",
-        "prop-types": "15.7.2"
+        "@babel/runtime": "^7.4.5",
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "read-pkg": {
@@ -11048,9 +11086,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
-        "load-json-file": "4.0.0",
-        "normalize-package-data": "2.5.0",
-        "path-type": "3.0.0"
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
       }
     },
     "read-pkg-up": {
@@ -11058,8 +11096,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
       "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
       "requires": {
-        "find-up": "3.0.0",
-        "read-pkg": "3.0.0"
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -11067,9 +11105,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.4.0.tgz",
       "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
       "requires": {
-        "inherits": "2.0.4",
-        "string_decoder": "1.3.0",
-        "util-deprecate": "1.0.2"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -11077,9 +11115,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "requires": {
-        "graceful-fs": "4.2.2",
-        "micromatch": "3.1.10",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       },
       "dependencies": {
         "readable-stream": {
@@ -11087,13 +11125,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -11101,7 +11139,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -11111,7 +11149,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/realpath-native/-/realpath-native-1.1.0.tgz",
       "integrity": "sha1-IAMpT+oj+wZy8kduviL89Jii1lw=",
       "requires": {
-        "util.promisify": "1.0.0"
+        "util.promisify": "^1.0.0"
       }
     },
     "recursive-readdir": {
@@ -11132,7 +11170,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha1-71Hg8OpK1CS3e/fLQfPgFccKPw4=",
       "requires": {
-        "regenerate": "1.4.0"
+        "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -11145,7 +11183,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
       "integrity": "sha1-Oy/OThq3cywI9mXf2zFHScfd0vs=",
       "requires": {
-        "private": "0.1.8"
+        "private": "^0.1.6"
       }
     },
     "regex-not": {
@@ -11153,8 +11191,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regex-parser": {
@@ -11177,12 +11215,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/regexpu-core/-/regexpu-core-4.5.5.tgz",
       "integrity": "sha1-qv/mHCr1gmmz5Ra2GnN5A3YyZBE=",
       "requires": {
-        "regenerate": "1.4.0",
-        "regenerate-unicode-properties": "8.1.0",
-        "regjsgen": "0.5.0",
-        "regjsparser": "0.6.0",
-        "unicode-match-property-ecmascript": "1.0.4",
-        "unicode-match-property-value-ecmascript": "1.1.0"
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.1.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
       }
     },
     "regjsgen": {
@@ -11195,7 +11233,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha1-8eaui32iuulsmTmbhozWyTOiupw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -11220,11 +11258,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/renderkid/-/renderkid-2.0.3.tgz",
       "integrity": "sha1-OAF5wv9a4TZcUivy/Pz/AcW3QUk=",
       "requires": {
-        "css-select": "1.2.0",
-        "dom-converter": "0.2.0",
-        "htmlparser2": "3.10.1",
-        "strip-ansi": "3.0.1",
-        "utila": "0.4.0"
+        "css-select": "^1.1.0",
+        "dom-converter": "^0.2",
+        "htmlparser2": "^3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "^0.4.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11237,10 +11275,10 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "requires": {
-            "boolbase": "1.0.0",
-            "css-what": "2.1.3",
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
             "domutils": "1.5.1",
-            "nth-check": "1.0.2"
+            "nth-check": "~1.0.1"
           }
         },
         "domutils": {
@@ -11248,8 +11286,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/domutils/-/domutils-1.5.1.tgz",
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "requires": {
-            "dom-serializer": "0.2.1",
-            "domelementtype": "1.3.1"
+            "dom-serializer": "0",
+            "domelementtype": "1"
           }
         },
         "strip-ansi": {
@@ -11257,7 +11295,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -11277,26 +11315,26 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/request/-/request-2.88.0.tgz",
       "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.8",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.24",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "punycode": {
@@ -11309,8 +11347,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
           "requires": {
-            "psl": "1.3.0",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         }
       }
@@ -11320,7 +11358,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
       "requires": {
-        "lodash": "4.17.15"
+        "lodash": "^4.17.11"
       }
     },
     "request-promise-native": {
@@ -11329,8 +11367,8 @@
       "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
       "requires": {
         "request-promise-core": "1.1.2",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.5.0"
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -11353,7 +11391,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
@@ -11361,7 +11399,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-from": {
@@ -11401,9 +11439,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha1-RSftaxyg2CxTzl7BogQcI0a71uU=",
           "requires": {
-            "chalk": "2.4.2",
-            "source-map": "0.6.1",
-            "supports-color": "6.1.0"
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
           }
         },
         "source-map": {
@@ -11416,7 +11454,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -11426,8 +11464,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
       "requires": {
-        "onetime": "5.1.0",
-        "signal-exit": "3.0.2"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -11440,8 +11478,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/rework/-/rework-1.0.1.tgz",
       "integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
       "requires": {
-        "convert-source-map": "0.3.5",
-        "css": "2.2.4"
+        "convert-source-map": "^0.3.3",
+        "css": "^2.0.0"
       },
       "dependencies": {
         "convert-source-map": {
@@ -11471,7 +11509,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "requires": {
-        "glob": "7.1.4"
+        "glob": "^7.1.3"
       }
     },
     "ripemd160": {
@@ -11479,8 +11517,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.4"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rsvp": {
@@ -11493,7 +11531,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-queue": {
@@ -11501,7 +11539,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "rxjs": {
@@ -11509,7 +11547,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/rxjs/-/rxjs-6.5.2.tgz",
       "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -11522,7 +11560,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -11535,15 +11573,15 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/sane/-/sane-4.1.0.tgz",
       "integrity": "sha1-7Ygf2SJzOmxGG8GJ3CtsAG8//e0=",
       "requires": {
-        "@cnakazawa/watch": "1.0.3",
-        "anymatch": "2.0.0",
-        "capture-exit": "2.0.0",
-        "exec-sh": "0.3.2",
-        "execa": "1.0.0",
-        "fb-watchman": "2.0.0",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7"
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
       }
     },
     "sass-loader": {
@@ -11551,11 +11589,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/sass-loader/-/sass-loader-7.2.0.tgz",
       "integrity": "sha1-40EVI5MJ0VslJ8titd/vtiqW/38=",
       "requires": {
-        "clone-deep": "4.0.1",
-        "loader-utils": "1.2.3",
-        "neo-async": "2.6.1",
-        "pify": "4.0.1",
-        "semver": "5.7.1"
+        "clone-deep": "^4.0.1",
+        "loader-utils": "^1.0.1",
+        "neo-async": "^2.5.0",
+        "pify": "^4.0.1",
+        "semver": "^5.5.0"
       },
       "dependencies": {
         "clone-deep": {
@@ -11563,9 +11601,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/clone-deep/-/clone-deep-4.0.1.tgz",
           "integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
           "requires": {
-            "is-plain-object": "2.0.4",
-            "kind-of": "6.0.2",
-            "shallow-clone": "3.0.1"
+            "is-plain-object": "^2.0.4",
+            "kind-of": "^6.0.2",
+            "shallow-clone": "^3.0.0"
           }
         },
         "kind-of": {
@@ -11588,7 +11626,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/shallow-clone/-/shallow-clone-3.0.1.tgz",
           "integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -11603,7 +11641,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/saxes/-/saxes-3.1.11.tgz",
       "integrity": "sha1-1Z0f0zLskq2YouCy7mRHAjhLHFs=",
       "requires": {
-        "xmlchars": "2.1.1"
+        "xmlchars": "^2.1.1"
       }
     },
     "scheduler": {
@@ -11611,8 +11649,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/scheduler/-/scheduler-0.15.0.tgz",
       "integrity": "sha1-a/z4D/hQsoD+1K7sxlE7wLTxf44=",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "schema-utils": {
@@ -11620,9 +11658,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
       "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
       "requires": {
-        "ajv": "6.10.2",
-        "ajv-errors": "1.0.1",
-        "ajv-keywords": "3.4.1"
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
       }
     },
     "select-hose": {
@@ -11649,18 +11687,18 @@
       "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.7.2",
+        "http-errors": "~1.7.2",
         "mime": "1.6.0",
         "ms": "2.1.1",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.1",
-        "statuses": "1.5.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -11700,13 +11738,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.3",
-        "mime-types": "2.1.24",
-        "parseurl": "1.3.3"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -11722,10 +11760,10 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "inherits": {
@@ -11750,9 +11788,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.3",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
         "send": "0.17.1"
       }
     },
@@ -11766,10 +11804,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -11777,7 +11815,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -11797,8 +11835,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "requires": {
-        "inherits": "2.0.4",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-clone": {
@@ -11806,10 +11844,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "2.0.1",
-        "lazy-cache": "0.2.7",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -11817,7 +11855,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.0.2"
           }
         },
         "lazy-cache": {
@@ -11832,7 +11870,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -11845,10 +11883,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "shellwords": {
@@ -11866,7 +11904,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "0.3.2"
+        "is-arrayish": "^0.3.1"
       },
       "dependencies": {
         "is-arrayish": {
@@ -11891,9 +11929,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "astral-regex": "1.0.0",
-        "is-fullwidth-code-point": "2.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -11908,14 +11946,14 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.1"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -11931,7 +11969,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -11939,7 +11977,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "ms": {
@@ -11954,9 +11992,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -11964,7 +12002,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -11972,7 +12010,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -11980,7 +12018,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -11988,9 +12026,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -12005,7 +12043,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "sockjs": {
@@ -12013,8 +12051,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha1-2Xa76ACve9IK4IWY1YI5NQiZPA0=",
       "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "3.3.2"
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.0.1"
       },
       "dependencies": {
         "faye-websocket": {
@@ -12022,7 +12060,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
-            "websocket-driver": "0.7.3"
+            "websocket-driver": ">=0.5.1"
           }
         }
       }
@@ -12032,12 +12070,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/sockjs-client/-/sockjs-client-1.3.0.tgz",
       "integrity": "sha1-EvydbLZj2lc509xftuhofalcsXc=",
       "requires": {
-        "debug": "3.2.6",
-        "eventsource": "1.0.7",
-        "faye-websocket": "0.11.3",
-        "inherits": "2.0.4",
-        "json3": "3.3.3",
-        "url-parse": "1.4.7"
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
       },
       "dependencies": {
         "debug": {
@@ -12045,7 +12083,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         }
       }
@@ -12065,11 +12103,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
       "requires": {
-        "atob": "2.1.2",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -12077,8 +12115,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "requires": {
-        "buffer-from": "1.1.1",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -12098,8 +12136,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.5"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -12112,8 +12150,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "requires": {
-        "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.5"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -12126,11 +12164,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/spdy/-/spdy-4.0.1.tgz",
       "integrity": "sha1-bxLtHF236k8k67i4m6WMh8CCV/I=",
       "requires": {
-        "debug": "4.1.1",
-        "handle-thing": "2.0.0",
-        "http-deceiver": "1.2.7",
-        "select-hose": "2.0.0",
-        "spdy-transport": "3.0.0"
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
       }
     },
     "spdy-transport": {
@@ -12138,12 +12176,12 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/spdy-transport/-/spdy-transport-3.0.0.tgz",
       "integrity": "sha1-ANSGOmQArXXfkzYaFghgXl3NzzE=",
       "requires": {
-        "debug": "4.1.1",
-        "detect-node": "2.0.4",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.2",
-        "readable-stream": "3.4.0",
-        "wbuf": "1.7.3"
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
       }
     },
     "split-string": {
@@ -12151,7 +12189,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -12164,15 +12202,15 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -12180,7 +12218,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ssri/-/ssri-6.0.1.tgz",
       "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
       "requires": {
-        "figgy-pudding": "3.5.1"
+        "figgy-pudding": "^3.5.1"
       }
     },
     "stable": {
@@ -12198,8 +12236,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -12207,7 +12245,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -12227,8 +12265,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
       "requires": {
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       },
       "dependencies": {
         "readable-stream": {
@@ -12236,13 +12274,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -12250,7 +12288,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -12260,8 +12298,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -12269,11 +12307,11 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.4",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.2"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -12281,13 +12319,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -12295,7 +12333,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -12305,28 +12343,13 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "requires": {
-        "safe-buffer": "5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk="
-        }
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12339,7 +12362,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -12349,9 +12372,24 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-width/-/string-width-4.1.0.tgz",
       "integrity": "sha1-uoRtHaqXw8WWFVMIBj4HXtHJmv8=",
       "requires": {
-        "emoji-regex": "8.0.0",
-        "is-fullwidth-code-point": "3.0.0",
-        "strip-ansi": "5.2.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^5.2.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk="
+        }
       }
     },
     "stringify-object": {
@@ -12359,9 +12397,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/stringify-object/-/stringify-object-3.3.0.tgz",
       "integrity": "sha1-cDBlrvyhkwDTzoivT1s5VtdVZik=",
       "requires": {
-        "get-own-enumerable-property-symbols": "3.0.0",
-        "is-obj": "1.0.1",
-        "is-regexp": "1.0.0"
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -12369,7 +12407,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "requires": {
-        "ansi-regex": "4.1.0"
+        "ansi-regex": "^4.1.0"
       }
     },
     "strip-bom": {
@@ -12382,8 +12420,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-comments/-/strip-comments-1.0.2.tgz",
       "integrity": "sha1-grnEXn8FhzvuU/NxaK+TCqNoZ50=",
       "requires": {
-        "babel-extract-comments": "1.0.0",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
+        "babel-extract-comments": "^1.0.0",
+        "babel-plugin-transform-object-rest-spread": "^6.26.0"
       }
     },
     "strip-eof": {
@@ -12401,8 +12439,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/style-loader/-/style-loader-1.0.0.tgz",
       "integrity": "sha1-HVKW+RZejiyF0k7uC3yvnsjKH4I=",
       "requires": {
-        "loader-utils": "1.2.3",
-        "schema-utils": "2.1.0"
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.1"
       },
       "dependencies": {
         "schema-utils": {
@@ -12410,8 +12448,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/schema-utils/-/schema-utils-2.1.0.tgz",
           "integrity": "sha1-lANjtrHsQHgAoilRvcwjNjwDk5M=",
           "requires": {
-            "ajv": "6.10.2",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -12421,19 +12459,19 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/styled-components/-/styled-components-4.3.2.tgz",
       "integrity": "sha1-TKgZGMgS0wBvYKxf3sfWtkqVCcw=",
       "requires": {
-        "@babel/helper-module-imports": "7.0.0",
-        "@babel/traverse": "7.5.5",
-        "@emotion/is-prop-valid": "0.8.2",
-        "@emotion/unitless": "0.7.4",
-        "babel-plugin-styled-components": "1.10.6",
-        "css-to-react-native": "2.3.1",
-        "memoize-one": "5.0.5",
-        "merge-anything": "2.4.1",
-        "prop-types": "15.7.2",
-        "react-is": "16.9.0",
-        "stylis": "3.5.4",
-        "stylis-rule-sheet": "0.0.10",
-        "supports-color": "5.5.0"
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@emotion/is-prop-valid": "^0.8.1",
+        "@emotion/unitless": "^0.7.0",
+        "babel-plugin-styled-components": ">= 1",
+        "css-to-react-native": "^2.2.2",
+        "memoize-one": "^5.0.0",
+        "merge-anything": "^2.2.4",
+        "prop-types": "^15.5.4",
+        "react-is": "^16.6.0",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10",
+        "supports-color": "^5.5.0"
       }
     },
     "stylehacks": {
@@ -12441,9 +12479,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/stylehacks/-/stylehacks-4.0.3.tgz",
       "integrity": "sha1-Zxj8r00eB9ihMYaQiB6NlnJqcdU=",
       "requires": {
-        "browserslist": "4.6.6",
-        "postcss": "7.0.17",
-        "postcss-selector-parser": "3.1.1"
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
       },
       "dependencies": {
         "postcss-selector-parser": {
@@ -12451,9 +12489,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
-            "dot-prop": "4.2.0",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }
@@ -12473,7 +12511,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "svg-parser": {
@@ -12486,19 +12524,19 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/svgo/-/svgo-1.3.0.tgz",
       "integrity": "sha1-uuUbqV3tmjOja3xGzpw1mukVQxM=",
       "requires": {
-        "chalk": "2.4.2",
-        "coa": "2.0.2",
-        "css-select": "2.0.2",
-        "css-select-base-adapter": "0.1.1",
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
         "css-tree": "1.0.0-alpha.33",
-        "csso": "3.5.1",
-        "js-yaml": "3.13.1",
-        "mkdirp": "0.5.1",
-        "object.values": "1.1.0",
-        "sax": "1.2.4",
-        "stable": "0.1.8",
-        "unquote": "1.1.1",
-        "util.promisify": "1.0.0"
+        "csso": "^3.5.1",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
       }
     },
     "symbol-observable": {
@@ -12516,10 +12554,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/table/-/table-5.4.6.tgz",
       "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
       "requires": {
-        "ajv": "6.10.2",
-        "lodash": "4.17.15",
-        "slice-ansi": "2.1.0",
-        "string-width": "3.1.0"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -12537,9 +12575,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -12554,9 +12592,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/terser/-/terser-4.1.4.tgz",
       "integrity": "sha1-RHi2oIuwlqYeeT/qGkQ0QIurk2w=",
       "requires": {
-        "commander": "2.20.0",
-        "source-map": "0.6.1",
-        "source-map-support": "0.5.13"
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
       },
       "dependencies": {
         "source-map": {
@@ -12571,15 +12609,15 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
       "integrity": "sha1-YbGOQOruW+l+dxzbsQ7RKAiIwrQ=",
       "requires": {
-        "cacache": "12.0.2",
-        "find-cache-dir": "2.1.0",
-        "is-wsl": "1.1.0",
-        "schema-utils": "1.0.0",
-        "serialize-javascript": "1.7.0",
-        "source-map": "0.6.1",
-        "terser": "4.1.4",
-        "webpack-sources": "1.4.3",
-        "worker-farm": "1.7.0"
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^1.7.0",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
       },
       "dependencies": {
         "source-map": {
@@ -12594,10 +12632,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/test-exclude/-/test-exclude-5.2.3.tgz",
       "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
       "requires": {
-        "glob": "7.1.4",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "4.0.0",
-        "require-main-filename": "2.0.0"
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
       }
     },
     "text-table": {
@@ -12620,8 +12658,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.2"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -12629,13 +12667,13 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.4",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.1",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -12643,7 +12681,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -12658,7 +12696,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/timers-browserify/-/timers-browserify-2.0.11.tgz",
       "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "timsort": {
@@ -12676,7 +12714,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -12699,7 +12737,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -12707,10 +12745,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -12718,8 +12756,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "toidentifier": {
@@ -12732,8 +12770,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "requires": {
-        "psl": "1.3.0",
-        "punycode": "2.1.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -12741,7 +12779,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "trim-right": {
@@ -12754,7 +12792,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ts-invariant/-/ts-invariant-0.4.4.tgz",
       "integrity": "sha1-l6UjUYaI+TqvrQGw6A64A+sqvYY=",
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.9.3"
       }
     },
     "ts-pnp": {
@@ -12772,7 +12810,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/tsutils/-/tsutils-3.17.1.tgz",
       "integrity": "sha1-7XGZF/EcoN7lhicrKsSeAVot11k=",
       "requires": {
-        "tslib": "1.10.0"
+        "tslib": "^1.8.1"
       }
     },
     "tty-browserify": {
@@ -12785,7 +12823,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -12803,7 +12841,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-fest": {
@@ -12817,7 +12855,7 @@
       "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.24"
+        "mime-types": "~2.1.24"
       }
     },
     "typedarray": {
@@ -12835,8 +12873,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/uglify-js/-/uglify-js-3.4.10.tgz",
       "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
       "requires": {
-        "commander": "2.19.0",
-        "source-map": "0.6.1"
+        "commander": "~2.19.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -12861,8 +12899,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "1.0.4",
-        "unicode-property-aliases-ecmascript": "1.0.5"
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -12880,10 +12918,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "2.0.1"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {
@@ -12901,7 +12939,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
       "requires": {
-        "unique-slug": "2.0.2"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -12909,7 +12947,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "universalify": {
@@ -12932,8 +12970,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -12941,9 +12979,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -12978,7 +13016,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -13007,9 +13045,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/url-loader/-/url-loader-2.1.0.tgz",
       "integrity": "sha1-vMHsq70ZfpE+yiP14DeOJLRBKWE=",
       "requires": {
-        "loader-utils": "1.2.3",
-        "mime": "2.4.4",
-        "schema-utils": "2.1.0"
+        "loader-utils": "^1.2.3",
+        "mime": "^2.4.4",
+        "schema-utils": "^2.0.0"
       },
       "dependencies": {
         "schema-utils": {
@@ -13017,8 +13055,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/schema-utils/-/schema-utils-2.1.0.tgz",
           "integrity": "sha1-lANjtrHsQHgAoilRvcwjNjwDk5M=",
           "requires": {
-            "ajv": "6.10.2",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -13028,8 +13066,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha1-qKg1NejACjFuQDpdtKwbm4U64ng=",
       "requires": {
-        "querystringify": "2.1.1",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "use": {
@@ -13062,8 +13100,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "requires": {
-        "define-properties": "1.1.3",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "utila": {
@@ -13091,8 +13129,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "requires": {
-        "spdx-correct": "3.1.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -13110,9 +13148,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -13125,7 +13163,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "requires": {
-        "browser-process-hrtime": "0.1.3"
+        "browser-process-hrtime": "^0.1.2"
       }
     },
     "w3c-xmlserializer": {
@@ -13133,9 +13171,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
       "integrity": "sha1-MEhcp9cKb9BSQgo9Ev2Q5jOc55Q=",
       "requires": {
-        "domexception": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "xml-name-validator": "3.0.0"
+        "domexception": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "xml-name-validator": "^3.0.0"
       }
     },
     "walker": {
@@ -13143,7 +13181,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "warning": {
@@ -13151,7 +13189,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
@@ -13159,9 +13197,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
       "requires": {
-        "chokidar": "2.1.6",
-        "graceful-fs": "4.2.2",
-        "neo-async": "2.6.1"
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
       }
     },
     "wbuf": {
@@ -13169,7 +13207,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "requires": {
-        "minimalistic-assert": "1.0.1"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "webidl-conversions": {
@@ -13186,25 +13224,25 @@
         "@webassemblyjs/helper-module-context": "1.8.5",
         "@webassemblyjs/wasm-edit": "1.8.5",
         "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "6.3.0",
-        "ajv": "6.10.2",
-        "ajv-keywords": "3.4.1",
-        "chrome-trace-event": "1.0.2",
-        "enhanced-resolve": "4.1.0",
-        "eslint-scope": "4.0.3",
-        "json-parse-better-errors": "1.0.2",
-        "loader-runner": "2.4.0",
-        "loader-utils": "1.2.3",
-        "memory-fs": "0.4.1",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.1",
-        "neo-async": "2.6.1",
-        "node-libs-browser": "2.2.1",
-        "schema-utils": "1.0.0",
-        "tapable": "1.1.3",
-        "terser-webpack-plugin": "1.4.1",
-        "watchpack": "1.6.0",
-        "webpack-sources": "1.4.3"
+        "acorn": "^6.2.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.1.0",
+        "eslint-scope": "^4.0.3",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.1",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.1",
+        "watchpack": "^1.6.0",
+        "webpack-sources": "^1.4.1"
       }
     },
     "webpack-dev-middleware": {
@@ -13212,10 +13250,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
       "integrity": "sha1-73UdJfTppcijXaYAxf2jWCtcbP8=",
       "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "2.4.4",
-        "range-parser": "1.2.1",
-        "webpack-log": "2.0.0"
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.2",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
       }
     },
     "webpack-dev-server": {
@@ -13224,34 +13262,34 @@
       "integrity": "sha1-G0XOPs/FW26+Xjbasnd8ArxQjE4=",
       "requires": {
         "ansi-html": "0.0.7",
-        "bonjour": "3.5.0",
-        "chokidar": "2.1.6",
-        "compression": "1.7.4",
-        "connect-history-api-fallback": "1.6.0",
-        "debug": "4.1.1",
-        "del": "3.0.0",
-        "express": "4.17.1",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.19.1",
-        "import-local": "2.0.0",
-        "internal-ip": "4.3.0",
-        "ip": "1.1.5",
-        "killable": "1.0.1",
-        "loglevel": "1.6.3",
-        "opn": "5.5.0",
-        "portfinder": "1.0.22",
-        "schema-utils": "1.0.0",
-        "selfsigned": "1.10.4",
-        "semver": "5.7.1",
-        "serve-index": "1.9.1",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^4.1.1",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
         "sockjs": "0.3.19",
         "sockjs-client": "1.3.0",
-        "spdy": "4.0.1",
-        "strip-ansi": "3.0.1",
-        "supports-color": "6.1.0",
-        "url": "0.11.0",
-        "webpack-dev-middleware": "3.7.0",
-        "webpack-log": "2.0.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.5.1",
+        "webpack-log": "^2.0.0",
         "yargs": "12.0.2"
       },
       "dependencies": {
@@ -13270,9 +13308,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -13285,7 +13323,7 @@
               "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -13323,8 +13361,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -13337,7 +13375,7 @@
               "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -13347,7 +13385,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -13355,7 +13393,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "wrap-ansi": {
@@ -13363,8 +13401,8 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -13372,7 +13410,7 @@
               "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -13380,9 +13418,9 @@
               "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -13392,18 +13430,18 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/yargs/-/yargs-12.0.2.tgz",
           "integrity": "sha1-/lgjQ2k5KvM+y+9TgZFx7/D1qtw=",
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "2.0.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "3.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "10.1.0"
+            "cliui": "^4.0.0",
+            "decamelize": "^2.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^10.1.0"
           }
         },
         "yargs-parser": {
@@ -13411,7 +13449,7 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-10.1.0.tgz",
           "integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -13421,8 +13459,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/webpack-log/-/webpack-log-2.0.0.tgz",
       "integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
       "requires": {
-        "ansi-colors": "3.2.4",
-        "uuid": "3.3.2"
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
       }
     },
     "webpack-manifest-plugin": {
@@ -13430,9 +13468,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
       "integrity": "sha1-5MopmbCVV3Fri6RHX7efq1mG8M0=",
       "requires": {
-        "fs-extra": "7.0.1",
-        "lodash": "4.17.15",
-        "tapable": "1.1.3"
+        "fs-extra": "^7.0.0",
+        "lodash": ">=3.5 <5",
+        "tapable": "^1.0.0"
       }
     },
     "webpack-sources": {
@@ -13440,8 +13478,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/webpack-sources/-/webpack-sources-1.4.3.tgz",
       "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
       "requires": {
-        "source-list-map": "2.0.1",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -13456,9 +13494,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/websocket-driver/-/websocket-driver-0.7.3.tgz",
       "integrity": "sha1-otTg1PTxFvHmKX66WLBdQwEA6fk=",
       "requires": {
-        "http-parser-js": "0.4.10",
-        "safe-buffer": "5.1.2",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -13489,9 +13527,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {
@@ -13499,7 +13537,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/which/-/which-1.3.1.tgz",
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -13517,7 +13555,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-background-sync/-/workbox-background-sync-4.3.1.tgz",
       "integrity": "sha1-JoIbm/Funjf9HWQCie3dwIr9GVA=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-broadcast-update": {
@@ -13525,7 +13563,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-broadcast-update/-/workbox-broadcast-update-4.3.1.tgz",
       "integrity": "sha1-4sAoCxSeOlBJg7dXYGrQQfMyw1s=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-build": {
@@ -13533,29 +13571,29 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-build/-/workbox-build-4.3.1.tgz",
       "integrity": "sha1-QU9w+01t5H9lOGCLgOxSQS0jPmQ=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "@hapi/joi": "15.1.1",
-        "common-tags": "1.8.0",
-        "fs-extra": "4.0.3",
-        "glob": "7.1.4",
-        "lodash.template": "4.5.0",
-        "pretty-bytes": "5.3.0",
-        "stringify-object": "3.3.0",
-        "strip-comments": "1.0.2",
-        "workbox-background-sync": "4.3.1",
-        "workbox-broadcast-update": "4.3.1",
-        "workbox-cacheable-response": "4.3.1",
-        "workbox-core": "4.3.1",
-        "workbox-expiration": "4.3.1",
-        "workbox-google-analytics": "4.3.1",
-        "workbox-navigation-preload": "4.3.1",
-        "workbox-precaching": "4.3.1",
-        "workbox-range-requests": "4.3.1",
-        "workbox-routing": "4.3.1",
-        "workbox-strategies": "4.3.1",
-        "workbox-streams": "4.3.1",
-        "workbox-sw": "4.3.1",
-        "workbox-window": "4.3.1"
+        "@babel/runtime": "^7.3.4",
+        "@hapi/joi": "^15.0.0",
+        "common-tags": "^1.8.0",
+        "fs-extra": "^4.0.2",
+        "glob": "^7.1.3",
+        "lodash.template": "^4.4.0",
+        "pretty-bytes": "^5.1.0",
+        "stringify-object": "^3.3.0",
+        "strip-comments": "^1.0.2",
+        "workbox-background-sync": "^4.3.1",
+        "workbox-broadcast-update": "^4.3.1",
+        "workbox-cacheable-response": "^4.3.1",
+        "workbox-core": "^4.3.1",
+        "workbox-expiration": "^4.3.1",
+        "workbox-google-analytics": "^4.3.1",
+        "workbox-navigation-preload": "^4.3.1",
+        "workbox-precaching": "^4.3.1",
+        "workbox-range-requests": "^4.3.1",
+        "workbox-routing": "^4.3.1",
+        "workbox-strategies": "^4.3.1",
+        "workbox-streams": "^4.3.1",
+        "workbox-sw": "^4.3.1",
+        "workbox-window": "^4.3.1"
       },
       "dependencies": {
         "fs-extra": {
@@ -13563,9 +13601,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha1-DYUhIuW8W+tFP7Ao6cDJvzY0DJQ=",
           "requires": {
-            "graceful-fs": "4.2.2",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         }
       }
@@ -13575,7 +13613,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-cacheable-response/-/workbox-cacheable-response-4.3.1.tgz",
       "integrity": "sha1-9T4HkXnAlaPxnlMTsoSXXJFCjJE=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-core": {
@@ -13588,7 +13626,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-expiration/-/workbox-expiration-4.3.1.tgz",
       "integrity": "sha1-15BDNWICnlaDfzQdf1U8Snjr6SE=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-google-analytics": {
@@ -13596,10 +13634,10 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-google-analytics/-/workbox-google-analytics-4.3.1.tgz",
       "integrity": "sha1-ntoBg7EDiQtcJW5vTqFaHxVIUZo=",
       "requires": {
-        "workbox-background-sync": "4.3.1",
-        "workbox-core": "4.3.1",
-        "workbox-routing": "4.3.1",
-        "workbox-strategies": "4.3.1"
+        "workbox-background-sync": "^4.3.1",
+        "workbox-core": "^4.3.1",
+        "workbox-routing": "^4.3.1",
+        "workbox-strategies": "^4.3.1"
       }
     },
     "workbox-navigation-preload": {
@@ -13607,7 +13645,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-navigation-preload/-/workbox-navigation-preload-4.3.1.tgz",
       "integrity": "sha1-Kcjk21hDgDs0zZbcFV+evZr6RT0=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-precaching": {
@@ -13615,7 +13653,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-precaching/-/workbox-precaching-4.3.1.tgz",
       "integrity": "sha1-n8Re0SLZS74fDqlYT/WUCWB3HLo=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-range-requests": {
@@ -13623,7 +13661,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-range-requests/-/workbox-range-requests-4.3.1.tgz",
       "integrity": "sha1-+KRwGIkiFFy/DAmpotXjVkUkTnQ=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-routing": {
@@ -13631,7 +13669,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-routing/-/workbox-routing-4.3.1.tgz",
       "integrity": "sha1-pnWEGvYj4LsMZ85O2OckrAvtDNo=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-strategies": {
@@ -13639,7 +13677,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-strategies/-/workbox-strategies-4.3.1.tgz",
       "integrity": "sha1-0r4DxO8hTBFeGrKcnHWcn+Pp5kY=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-streams": {
@@ -13647,7 +13685,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-streams/-/workbox-streams-4.3.1.tgz",
       "integrity": "sha1-C1facOmCVy3gnIdC3Qy0Cmt8LMM=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "workbox-sw": {
@@ -13660,9 +13698,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-webpack-plugin/-/workbox-webpack-plugin-4.3.1.tgz",
       "integrity": "sha1-R/9eocwHS2xA+1qGEIhjokEg1L0=",
       "requires": {
-        "@babel/runtime": "7.5.5",
-        "json-stable-stringify": "1.0.1",
-        "workbox-build": "4.3.1"
+        "@babel/runtime": "^7.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "workbox-build": "^4.3.1"
       }
     },
     "workbox-window": {
@@ -13670,7 +13708,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/workbox-window/-/workbox-window-4.3.1.tgz",
       "integrity": "sha1-7mBRvxDwavpUg8m436BTGZTt4PM=",
       "requires": {
-        "workbox-core": "4.3.1"
+        "workbox-core": "^4.3.1"
       }
     },
     "worker-farm": {
@@ -13678,7 +13716,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/worker-farm/-/worker-farm-1.7.0.tgz",
       "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.7"
       }
     },
     "worker-rpc": {
@@ -13686,7 +13724,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/worker-rpc/-/worker-rpc-0.1.1.tgz",
       "integrity": "sha1-y1Zb1tcHGo8WZgaGBR6WmtMvVNU=",
       "requires": {
-        "microevent.ts": "0.1.1"
+        "microevent.ts": "~0.1.1"
       }
     },
     "wrap-ansi": {
@@ -13694,9 +13732,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -13714,9 +13752,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -13731,7 +13769,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/write/-/write-1.0.3.tgz",
       "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -13739,9 +13777,9 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
       "integrity": "sha1-0LBUY8GIroBDlv1asqNwBir4dSk=",
       "requires": {
-        "graceful-fs": "4.2.2",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -13749,7 +13787,7 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/ws/-/ws-5.2.2.tgz",
       "integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
       "requires": {
-        "async-limiter": "1.0.1"
+        "async-limiter": "~1.0.0"
       }
     },
     "xml-name-validator": {
@@ -13787,16 +13825,16 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
       "requires": {
-        "cliui": "5.0.0",
-        "find-up": "3.0.0",
-        "get-caller-file": "2.0.5",
-        "require-directory": "2.1.1",
-        "require-main-filename": "2.0.0",
-        "set-blocking": "2.0.0",
-        "string-width": "3.1.0",
-        "which-module": "2.0.0",
-        "y18n": "4.0.0",
-        "yargs-parser": "13.1.1"
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
       },
       "dependencies": {
         "emoji-regex": {
@@ -13814,9 +13852,9 @@
           "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         }
       }
@@ -13826,8 +13864,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
       "requires": {
-        "camelcase": "5.3.1",
-        "decamelize": "1.2.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     },
     "zen-observable": {
@@ -13840,8 +13878,8 @@
       "resolved": "https://artifactory.spectrumtoolbox.com/artifactory/api/npm/npm/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz",
       "integrity": "sha1-wJTNIOg92wKhEUSm4qiXBpRrVpQ=",
       "requires": {
-        "tslib": "1.10.0",
-        "zen-observable": "0.8.14"
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/ui/src/components/Checkbox/index.js
+++ b/ui/src/components/Checkbox/index.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { withStyles } from "@material-ui/core/styles";
+import { blue } from "@material-ui/core/colors";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
+
+const BlueCheckbox = withStyles({
+  root: {
+    color: blue[100],
+    "&$checked": {
+      color: blue[300]
+    }
+  },
+  checked: {}
+})(props => <Checkbox color="default" {...props} />);
+
+export default function CheckboxLabels({
+  label,
+  checked,
+  handleChange,
+  action
+}) {
+  return (
+    <FormControlLabel
+      control={
+        <BlueCheckbox
+          checked={checked}
+          onChange={() => handleChange(!checked, action)}
+          value="checked"
+        />
+      }
+      label={label}
+    />
+  );
+}

--- a/ui/src/components/MultipleSelect/index.js
+++ b/ui/src/components/MultipleSelect/index.js
@@ -1,0 +1,92 @@
+import React from "react";
+import { makeStyles, useTheme } from "@material-ui/core/styles";
+import Input from "@material-ui/core/Input";
+import InputLabel from "@material-ui/core/InputLabel";
+import MenuItem from "@material-ui/core/MenuItem";
+import FormControl from "@material-ui/core/FormControl";
+import Select from "@material-ui/core/Select";
+import Chip from "@material-ui/core/Chip";
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: "flex",
+    flexWrap: "wrap"
+  },
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: 120,
+    maxWidth: 300
+  },
+  chips: {
+    display: "flex",
+    flexWrap: "wrap"
+  },
+  chip: {
+    margin: 2
+  },
+  noLabel: {
+    marginTop: theme.spacing(3)
+  }
+}));
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250
+    }
+  }
+};
+
+function getStyles(option, options, theme) {
+  return {
+    fontWeight:
+      options.indexOf(option) === -1
+        ? theme.typography.fontWeightRegular
+        : theme.typography.fontWeightMedium
+  };
+}
+
+export default function MultipleSelect({
+  options,
+  label,
+  handleChange,
+  value
+}) {
+  const classes = useStyles();
+  const theme = useTheme();
+
+  return (
+    <div className={classes.root}>
+      <FormControl className={classes.formControl}>
+        <InputLabel>{label}</InputLabel>
+        <Select
+          multiple
+          value={value}
+          onChange={event => handleChange(event.target.value)}
+          input={<Input id="select-multiple-chip" />}
+          renderValue={selected => (
+            <div className={classes.chips}>
+              {selected.map(value => (
+                <Chip key={value} label={value} className={classes.chip} />
+              ))}
+            </div>
+          )}
+          MenuProps={MenuProps}
+        >
+          {options.map(option => (
+            <MenuItem
+              key={option}
+              value={option}
+              style={getStyles(option, options, theme)}
+            >
+              {option}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </div>
+  );
+}

--- a/ui/src/helpers/stateHelpers.js
+++ b/ui/src/helpers/stateHelpers.js
@@ -1,0 +1,17 @@
+export const loadState = (state) => {
+  try {
+    const serializedState = localStorage.getItem(state);
+    return serializedState === null ? undefined : JSON.parse(serializedState);
+  } catch (error) {
+    return undefined;
+  }
+};
+
+export const saveState = (state, data) => {
+  try {
+    const serializedState = JSON.stringify(data)
+    localStorage.setItem(state, serializedState);
+  } catch (error) {
+    // Ignore errors.
+  }
+};

--- a/ui/src/screens/home/index.js
+++ b/ui/src/screens/home/index.js
@@ -1,13 +1,48 @@
-import React from 'react'
-import { useQuery } from '@apollo/react-hooks'
-import { gql } from 'apollo-boost'
-import _ from 'lodash'
+import React, { useState } from "react"
+import Button from "@material-ui/core/Button"
+import { useQuery } from "@apollo/react-hooks"
+import { gql } from "apollo-boost"
+import _ from "lodash"
 
-import SearchBox from '../../components/SearchBox'
-import PokemonCard from '../../components/PokemonCard'
-import * as S from './styled'
+import SearchBox from "../../components/SearchBox"
+import PokemonCard from "../../components/PokemonCard"
+import MultipleSelect from "../../components/MultipleSelect"
+import Checkbox from "../../components/Checkbox"
+import * as S from "./styled"
+
+import { loadState, saveState } from "../../helpers/stateHelpers"
 
 export default function HomeScreen() {
+  const typeState = loadState("type");
+  const weaknessState = loadState("weakness");
+  const strictTypeState = loadState("strictType");
+
+  const [type, setType] = useState(typeState ? typeState : []);
+  const [weakness, setWeakness] = useState(weaknessState ? weaknessState : []);
+  const [strictType, setStrictType] = useState(
+    strictTypeState ? strictTypeState : false
+  );
+
+  function handleTypeChange(data) {
+    setType(data);
+    saveState("type", data);
+  }
+
+  function handleWeaknessChange(data) {
+    setWeakness(data);
+    saveState("weakness", data);
+  }
+
+  function handleStrictTypeChange(data) {
+    setStrictType(data);
+    saveState("strictType", data);
+  }
+
+  function handleClearType() {
+    handleTypeChange([]);
+    handleStrictTypeChange(false);
+  }
+
   const { loading, error, data } = useQuery(gql`
     {
       pokemonMany {
@@ -16,55 +51,111 @@ export default function HomeScreen() {
         img
         type
         weaknesses
+      },
+      types {
+        types
       }
     }
-  `)
+  `);
   if (loading)
     return (
       <S.Container>
         <p>Loading...</p>
       </S.Container>
-    )
+    );
   if (error)
     return (
       <S.Container>
         <p>Error :(</p>
       </S.Container>
-    )
+    );
   return (
     <S.Container>
       <h1>Pokédex</h1>
       <SearchBox
         suggestions={data.pokemonMany.map(pokemon => ({
           label: pokemon.name,
-          value: pokemon.num,
+          value: pokemon.num
         }))}
       >
         {searchValue => (
-          <S.Grid>
-            {data.pokemonMany
-              .filter(pokemon =>
-                searchValue
-                  ? _.deburr(pokemon.name.toLowerCase()).includes(
-                      _.deburr(searchValue.toLowerCase())
-                    )
-                  : true
-              )
-              .map(pokemon => (
-                <S.CardContainer key={pokemon.num}>
-                  <S.CardLink to={`/${pokemon.num}`}>
-                    <PokemonCard
-                      key={pokemon.num}
-                      pokemon={pokemon}
-                      isSmall
-                      animateHovering
-                    />
-                  </S.CardLink>
-                </S.CardContainer>
-              ))}
-          </S.Grid>
+          <>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-evenly"
+              }}
+            >
+              <div style={{ display: "flex" }}>
+                <MultipleSelect
+                  options={data.types[0].types}
+                  label="Types"
+                  handleChange={handleTypeChange}
+                  value={type}
+                />
+                <div style={{ alignSelf: "flex-end", paddingBottom: 12 }}>
+                  <Checkbox
+                    label="Strict Type Match"
+                    checked={strictType}
+                    handleChange={handleStrictTypeChange}
+                  />
+                </div>
+              </div>
+              <MultipleSelect
+                options={data.types[0].types}
+                label="Weaknesses"
+                handleChange={handleWeaknessChange}
+                value={weakness}
+              />
+            </div>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-around"
+              }}
+            >
+              <Button onClick={handleClearType}>Clear Type Filter</Button>
+              <Button onClick={() => handleWeaknessChange([])}>Clear Weakness Filter</Button>
+            </div>
+            <S.Grid>
+              {data.pokemonMany
+                .filter(pokemon =>
+                  searchValue
+                    ? _.deburr(pokemon.name.toLowerCase()).includes(
+                        _.deburr(searchValue.toLowerCase())
+                      )
+                    : true
+                )
+                .filter(pokemon =>
+                  type.length
+                    ? strictType
+                      ? type.every(t => pokemon.type.indexOf(t) > -1)
+                      : pokemon.type.some(t => type.includes(t))
+                    : true
+                )
+                .filter(pokemon =>
+                  weakness.length
+                    ? pokemon.weaknesses.some(w => weakness.includes(w))
+                    : true
+                )
+                .map(pokemon => (
+                  <S.CardContainer key={pokemon.num}>
+                    <S.CardLink to={`/${pokemon.num}`}>
+                      <PokemonCard
+                        key={pokemon.num}
+                        pokemon={pokemon}
+                        isSmall
+                        animateHovering
+                      />
+                    </S.CardLink>
+                  </S.CardContainer>
+                ))}
+            </S.Grid>
+          </>
         )}
       </SearchBox>
     </S.Container>
-  )
+  );
 }

--- a/ui/src/screens/home/index.js
+++ b/ui/src/screens/home/index.js
@@ -80,45 +80,33 @@ export default function HomeScreen() {
       >
         {searchValue => (
           <>
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "row",
-                justifyContent: "space-evenly"
-              }}
-            >
-              <div style={{ display: "flex" }}>
+            <S.FilterContainer>
+              <S.TypeFilterContainer>
                 <MultipleSelect
                   options={data.types[0].types}
                   label="Types"
                   handleChange={handleTypeChange}
                   value={type}
                 />
-                <div style={{ alignSelf: "flex-end", paddingBottom: 12 }}>
+                <S.CheckboxContainer>
                   <Checkbox
                     label="Strict Type Match"
                     checked={strictType}
                     handleChange={handleStrictTypeChange}
                   />
-                </div>
-              </div>
+                </S.CheckboxContainer>
+              </S.TypeFilterContainer>
               <MultipleSelect
                 options={data.types[0].types}
                 label="Weaknesses"
                 handleChange={handleWeaknessChange}
                 value={weakness}
               />
-            </div>
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "row",
-                justifyContent: "space-around"
-              }}
-            >
+            </S.FilterContainer>
+            <S.ButtonContainer>
               <Button onClick={handleClearType}>Clear Type Filter</Button>
               <Button onClick={() => handleWeaknessChange([])}>Clear Weakness Filter</Button>
-            </div>
+            </S.ButtonContainer>
             <S.Grid>
               {data.pokemonMany
                 .filter(pokemon =>

--- a/ui/src/screens/home/styled.js
+++ b/ui/src/screens/home/styled.js
@@ -24,3 +24,24 @@ export const CardContainer = styled.div`
 export const CardLink = styled(Link)`
   text-decoration: none;
 `
+
+export const FilterContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+`
+
+export const TypeFilterContainer = styled.div`
+  display: flex;
+`
+
+export const CheckboxContainer = styled.div`
+  align-self: flex-end;
+  padding-bottom: 12px;
+`
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+`

--- a/ui/src/screens/pokemon/index.js
+++ b/ui/src/screens/pokemon/index.js
@@ -13,7 +13,7 @@ import * as S from './styled'
 export default function PokemonScreen({ num }) {
   const { loading, error, data } = useQuery(gql`
     {
-      pokemonOne(id: ${num.replace(/0/g, '')}) {
+      pokemonOne(id: ${num.replace(/^00|^0/, '')}) {
         num
         name
         img


### PR DESCRIPTION
Implemented filtering by type and weakness according to AC.

Also added: text buttons to clear filters; strict type matching checkbox; filters save to local storage to prevent clearing on re-render of Home Screen.

Styling of the added components is done per the Material UI examples rather than with styled components, which I recognize is the pattern used in this take home. I made this decision because I wanted to focus on implementing the additional functionality I mentioned above and wanted to complete this in a reasonable amount of time.

I don't know much about GraphQL, but implemented a "types" schema/data to return that from the backend rather than using a hardcoded data structure on the front end -- it works fine, though it's probably not perfect, but I was too curious not to attempt it.

Thanks!